### PR TITLE
Fix FOAF namespace

### DIFF
--- a/core/src/test/java/org/apache/any23/extractor/rdfa/AbstractRDFaExtractorTestCase.java
+++ b/core/src/test/java/org/apache/any23/extractor/rdfa/AbstractRDFaExtractorTestCase.java
@@ -86,7 +86,7 @@ public abstract class AbstractRDFaExtractorTestCase extends AbstractExtractorTes
         );
         assertContains(
                 RDFUtils.uri("http://database.org/table/Departments"),
-                RDFUtils.uri("http://xmlns.org/foaf/01/author"),
+                RDFUtils.uri("http://xmlns.com/foaf/0.1/author"),
                 RDFUtils.uri("http://database.org/people/Davide_Palmisano")
         );
         assertContains(

--- a/src/site/apt/dev-csv-extractor.apt
+++ b/src/site/apt/dev-csv-extractor.apt
@@ -59,7 +59,7 @@ CSV Extractor Algorithm
   For example, given this trivial CSV with an header and just two rows:
 
 +---------------------------------------------------------------
-first name; last name; http://xmlns.org/foaf/01/knows; age
+first name; last name; http://xmlns.com/foaf/0.1/knows; age
 Davide; Palmisano; http://michelemostarda.com; 30; value should not appear
 Michele; Mostarda; http://g1o.net;
 +---------------------------------------------------------------
@@ -81,7 +81,7 @@ Michele; Mostarda; http://g1o.net;
     rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</columnPosition>
   </rdf:Description>
 
-  <rdf:Description rdf:about="http://xmlns.org/foaf/01/knows">
+  <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/knows">
     <columnPosition xmlns="http://vocab.sindice.net/csv/"
     rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</columnPosition>
   </rdf:Description>
@@ -98,7 +98,7 @@ Michele; Mostarda; http://g1o.net;
     rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Davide</firstName>
     <lastName xmlns="http://bob.example.com/"
     rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Palmisano</lastName>
-    <knows xmlns="http://xmlns.org/foaf/01/"
+    <knows xmlns="http://xmlns.com/foaf/0.1/"
     rdf:resource="http://michelemostarda.com"/
     <age xmlns="http://bob.example.com/"
     rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">30</age>
@@ -118,7 +118,7 @@ Michele; Mostarda; http://g1o.net;
     rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Michele</firstName>
     <lastName xmlns="http://bob.example.com/"
     rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mostarda</lastName>
-    <knows xmlns="http://xmlns.org/foaf/01/" rdf:resource="http://g1o.net" />
+    <knows xmlns="http://xmlns.com/foaf/0.1/" rdf:resource="http://g1o.net" />
   </rdf:Description>
 
   <rdf:Description rdf:about="http://bob.example.com/">

--- a/test-resources/src/test/resources/html/rdfa/rdfa-11-curies.html
+++ b/test-resources/src/test/resources/html/rdfa/rdfa-11-curies.html
@@ -26,7 +26,7 @@
     <div prefix="db: http://database.org/ dc: http://purl.org/dc/01/" about="db:table/Departments">
         <span property="db:description" content="Tables listing departments"></span>
        <span rel="db:owner" resource="[db:people/Davide_Palmisano]"></span>
-        <span prefix="foaf: http://xmlns.org/foaf/01/" rel="foaf:author"
+        <span prefix="foaf: http://xmlns.com/foaf/0.1/" rel="foaf:author"
               resource="db:people/Davide_Palmisano"></span>
         <span property="dc:name" content="Departments"></span>
     </div>

--- a/test-resources/src/test/resources/org/apache/any23/extractor/csv/test-comma.csv
+++ b/test-resources/src/test/resources/org/apache/any23/extractor/csv/test-comma.csv
@@ -1,4 +1,4 @@
-first name, last name, http://xmlns.org/foaf/01/knows, age
+first name, last name, http://xmlns.com/foaf/0.1/knows, age
 Davide, Palmisano, http://michelemostarda.com, 30, value should not appear
 Michele, Mostarda, http://g1o.net,
 Giovanni, Tummarello, http://twitter.com/cygri,

--- a/test-resources/src/test/resources/org/apache/any23/extractor/csv/test-missing.csv
+++ b/test-resources/src/test/resources/org/apache/any23/extractor/csv/test-missing.csv
@@ -1,4 +1,4 @@
-first name,last name,http://xmlns.org/foaf/01/knows,age
+first name,last name,http://xmlns.com/foaf/0.1/knows,age
 ,Palmisano,http://michelemostarda.com,30
 Michele,,http://g1o.net,
 Giovanni,Tummarello,,

--- a/test-resources/src/test/resources/org/apache/any23/extractor/csv/test-semicolon.csv
+++ b/test-resources/src/test/resources/org/apache/any23/extractor/csv/test-semicolon.csv
@@ -1,4 +1,4 @@
-first name; last name; http://xmlns.org/foaf/01/knows; age
+first name; last name; http://xmlns.com/foaf/0.1/knows; age
 Davide; Palmisano; http://michelemostarda.com; 30; value should not appear
 Michele; Mostarda; http://g1o.net;
 Giovanni; Tummarello; http://twitter.com/cygri;

--- a/test-resources/src/test/resources/org/apache/any23/extractor/csv/test-tab.csv
+++ b/test-resources/src/test/resources/org/apache/any23/extractor/csv/test-tab.csv
@@ -1,4 +1,4 @@
-first name	 last name	 http://xmlns.org/foaf/01/knows	 age
+first name	 last name	 http://xmlns.com/foaf/0.1/knows	 age
 Davide	 Palmisano	 http://michelemostarda.com	 30	 value should not appear
 Michele	 Mostarda	 http://g1o.net	
 Giovanni	 Tummarello	 http://twitter.com/cygri	


### PR DESCRIPTION
Not sure where that funky namespace came from (http://xmlns.org/foaf/01/), but it's not the official FOAF namespace which is http://xmlns.com/foaf/0.1/.
