### PR TITLE
Fix generation of BNode name for microdata when 'itemid' is given without a value.

### DIFF
--- a/core/src/main/java/org/apache/any23/extractor/microdata/ItemScope.java
+++ b/core/src/main/java/org/apache/any23/extractor/microdata/ItemScope.java
@@ -184,13 +184,12 @@ public class ItemScope extends Item {
 
     @Override
     public int hashCode() {
-            return
-                (properties == null ? 1 : properties.hashCode()) *
-                (id == null         ? 1 : id.hashCode()) * 2 *
-                (refs == null       ? 1 : refs.hashCode()) * 3 *
-                (type == null       ? 1 : type.hashCode()) * 5 *
-                (itemId == null     ? 1 : itemId.hashCode());
-
+	int i = properties == null ? 0 : properties.hashCode();
+	i += id == null         ? 0 : id.hashCode();
+	i += refs == null       ? 0 : refs.hashCode();
+	i += type == null       ? 0 : type.hashCode();
+	i += itemId == null     ? 0 : itemId.hashCode();
+	return i;
     }
 
     @Override

--- a/core/src/test/java/org/apache/any23/cli/ToolRunnerTest.java
+++ b/core/src/test/java/org/apache/any23/cli/ToolRunnerTest.java
@@ -46,6 +46,7 @@ public class ToolRunnerTest {
     @Test
     public void testGetToolsInClasspath() throws IOException {
         Iterator<Tool> tools = new ToolRunner().getToolsInClasspath();
+        assertTrue("No core tools have been detected", tools.hasNext());
         while (tools.hasNext()) {
             assertTrue("Some core tools have not been detected.", coreTools.contains(tools.next().getClass()));
         }


### PR DESCRIPTION
Fix generation of BNode name for microdata when 'itemid' is given with an empty value.
This results in using the MD5 of "0" in the name of BNodes: 'nodecfcd208495d565ef66e7dff9f98764da'
An example of where this is a problem is https://www.youtube.com/channel/UCQNIKO3SwRcYnoiuSqKYbOA
'<div id="watch-container" itemid="" itemscope itemtype="http://schema.org/YoutubeChannelV2">'

Also added a check to ToolRunnerTest for no tools.
