### PR TITLE
Fix for a ThreadSafety issue in ItemPropValue

### DIFF
--- a/core/src/main/java/org/apache/any23/extractor/html/microformats2/annotations/package-info.java
+++ b/core/src/main/java/org/apache/any23/extractor/html/microformats2/annotations/package-info.java
@@ -21,4 +21,4 @@
  *
  *  @see org.apache.any23.extractor.html.MicroformatExtractor
  */
-package org.apache.any23.extractor.microformats2.annotations;
+package org.apache.any23.extractor.html.microformats2.annotations;

--- a/core/src/main/java/org/apache/any23/extractor/microdata/ItemPropValue.java
+++ b/core/src/main/java/org/apache/any23/extractor/microdata/ItemPropValue.java
@@ -151,9 +151,7 @@ public class ItemPropValue {
      * @return <code>true</code> if type is an integer.
      */
     public boolean isInteger() {
-        if(type != Type.Plain) {
-            return false;
-        }
+        if(type != Type.Plain) return false;
          try {
              Integer.parseInt((String) content);
              return true;
@@ -166,9 +164,7 @@ public class ItemPropValue {
      * @return <code>true</code> if type is a float.
      */
      public boolean isFloat() {
-         if(type != Type.Plain) {
-            return false;
-        }
+         if(type != Type.Plain) return false;
          try {
              Float.parseFloat((String) content);
              return true;


### PR DESCRIPTION
When multiple HTML documents are parsed concurrently in different threads, the MicrodataParser will sometimes throw very weird Exceptions or deliver broken values of date properties. I tracked it to a static SimpleDateFormat field in ItemPropValue. SimpleDateFormat is not thread-safe and should never be used like this. 

I wrote a unit test that tries to parse the same document in 10 concurrent threads about 100 times each. Then it gets a value of the "birthday" property. In all thousand cases the value should be the same. On my machine this test fails each time with various errors. With the fix - the test passes each time. 

The test uses a cyclic barrier and ensures that only in-memory data is used, so that I/O overhead and thread creation overhead do not interfere with the actual processing under test.