### PR TITLE
ANY23-277 Any23 master branch will not build to to build due to lacking maven-assembly-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ target
 .project
 pom.xml.versionsBackup
 *~
+**/.externalToolBuilders/
+**/maven-eclipse.xml
+**/any23-site/

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -51,7 +51,6 @@
         <directory>${basedir}/src/main/resources</directory>
         <filtering>true</filtering>
       </resource>
-
       <resource>
         <directory>${basedir}/../</directory>
         <targetPath>META-INF</targetPath>
@@ -61,6 +60,29 @@
         </includes>
       </resource>
     </resources>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>${maven-assembly-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>assembly</id>
+              <phase>package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <attach>true</attach>
+            <skipAssembly>true</skipAssembly>
+            <tarLongFileMode>gnu</tarLongFileMode>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <profiles>

--- a/core/src/main/assembly/bin.xml
+++ b/core/src/main/assembly/bin.xml
@@ -34,25 +34,25 @@
     <file>
       <source>${basedir}/src/main/assembly/README.txt</source>
       <filtered>true</filtered>
-      <outputDirectory>/</outputDirectory>
-      <fileMode>666</fileMode>
+      <outputDirectory></outputDirectory>
+      <fileMode>0666</fileMode>
     </file>
     <file>
       <source>${basedir}/src/main/assembly/LICENSE-with-deps.txt</source>
       <destName>LICENSE.txt</destName>
-      <outputDirectory>/</outputDirectory>
-      <fileMode>666</fileMode>
+      <outputDirectory></outputDirectory>
+      <fileMode>0666</fileMode>
     </file>
     <file>
       <source>${basedir}/src/main/assembly/NOTICE-with-deps.txt</source>
       <destName>NOTICE.txt</destName>
-      <outputDirectory>/</outputDirectory>
-      <fileMode>666</fileMode>
+      <outputDirectory></outputDirectory>
+      <fileMode>0666</fileMode>
     </file>
     <file>
       <source>${basedir}/../RELEASE-NOTES.txt</source>
-      <outputDirectory>/</outputDirectory>
-      <fileMode>666</fileMode>
+      <outputDirectory></outputDirectory>
+      <fileMode>0666</fileMode>
     </file>
   </files>
 
@@ -63,7 +63,7 @@
     <fileSet>
       <directory>${project.build.directory}/appassembler/bin/</directory>
       <outputDirectory>/bin</outputDirectory>
-      <fileMode>755</fileMode>
+      <fileMode>0755</fileMode>
     </fileSet>
 
     <!--

--- a/csvutils/pom.xml
+++ b/csvutils/pom.xml
@@ -60,6 +60,29 @@
         </includes>
       </resource>
     </resources>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>${maven-assembly-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>assembly</id>
+              <phase>package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <attach>true</attach>
+            <skipAssembly>true</skipAssembly>
+            <tarLongFileMode>gnu</tarLongFileMode>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <profiles>

--- a/encoding/pom.xml
+++ b/encoding/pom.xml
@@ -70,6 +70,29 @@
         </includes>
       </resource>
     </resources>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>${maven-assembly-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>assembly</id>
+              <phase>package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <attach>true</attach>
+            <skipAssembly>true</skipAssembly>
+            <tarLongFileMode>gnu</tarLongFileMode>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <profiles>

--- a/mime/pom.xml
+++ b/mime/pom.xml
@@ -110,6 +110,29 @@
         </includes>
       </resource>
     </resources>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>${maven-assembly-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>assembly</id>
+              <phase>package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <attach>true</attach>
+            <skipAssembly>true</skipAssembly>
+            <tarLongFileMode>gnu</tarLongFileMode>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <profiles>

--- a/nquads/pom.xml
+++ b/nquads/pom.xml
@@ -85,6 +85,29 @@
         </includes>
       </resource>
     </resources>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>${maven-assembly-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>assembly</id>
+              <phase>package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <attach>true</attach>
+            <skipAssembly>true</skipAssembly>
+            <tarLongFileMode>gnu</tarLongFileMode>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <profiles>

--- a/test-resources/pom.xml
+++ b/test-resources/pom.xml
@@ -43,6 +43,29 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>${maven-assembly-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>assembly</id>
+              <phase>package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <attach>true</attach>
+            <skipAssembly>true</skipAssembly>
+            <tarLongFileMode>gnu</tarLongFileMode>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
 </project>


### PR DESCRIPTION
This issue addresses https://issues.apache.org/jira/browse/ANY23-277
It also adds some configuration to .gitignore for the any23-site as well as Eclipse files.
Would like to commit EoB today if possible. 