### PR TITLE
ANY23-293 Package log4j configuration with core appassembler

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -208,6 +208,9 @@
               <name>any23</name>
             </program>
           </programs>
+          <configurationDirectory>conf</configurationDirectory>
+          <configurationSourceDirectory>${basedir}/src/test/resources</configurationSourceDirectory>
+          <copyConfigurationDirectory>true</copyConfigurationDirectory>
         </configuration>
       </plugin>
 

--- a/core/src/main/assembly/bin.xml
+++ b/core/src/main/assembly/bin.xml
@@ -76,6 +76,14 @@
         <exclude>*.xml</exclude>
       </excludes>
     </fileSet>
+
+    <!--
+     | Configuration and Resources
+    -->
+    <fileSet>
+      <directory>${project.build.directory}/appassembler/conf/</directory>
+      <outputDirectory>/conf</outputDirectory>
+    </fileSet>
   </fileSets>
 
 </assembly>

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-log4j.rootCategory=DEBUG, O
+log4j.rootCategory=INFO, O
 
 # Stdout
 log4j.appender.O=org.apache.log4j.ConsoleAppender  

--- a/csvutils/src/test/resources/log4j.properties
+++ b/csvutils/src/test/resources/log4j.properties
@@ -1,3 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 log4j.rootCategory=INFO, R, O  
       
 # Stdout  

--- a/mime/src/test/resources/log4j.properties
+++ b/mime/src/test/resources/log4j.properties
@@ -1,3 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 log4j.rootCategory=INFO, O  
       
 # Stdout  

--- a/plugins/office-scraper/src/test/resources/log4j.properties
+++ b/plugins/office-scraper/src/test/resources/log4j.properties
@@ -1,3 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 log4j.rootCategory=INFO, O  
       
 # Stdout  

--- a/service/src/test/resources/log4j.properties
+++ b/service/src/test/resources/log4j.properties
@@ -1,3 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 log4j.rootCategory=INFO, O  
       
 # Stdout  


### PR DESCRIPTION
This PR addresses a few things
 * Packages log4j configuration with core appassembler
 * adds 4 missing license headers
 * changes core log4j verbosity from DEBUG to INFO