### PR TITLE
ANY23-235 NQuads links broken on Supported Formats Page

### DIFF
--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -32,7 +32,7 @@ Introduction to Apache Any23
 
      * {{{http://microformats.org/}Microformats1}} and {{{http://microformats.org/wiki/microformats-2}Microformats2}}: hAdr, hCard, hCalendar, hEntry, hEvent, hGeo, hItem, hListing, hProduct, hProduct, hRecipie, hResume, hReview, License, Species, XFN, etc
 
-      * {{http://json-ld.org/}JSON-LD}: JSON for Linking Data. a lightweight Linked Data format based on the already successful JSON format and provides a way to help JSON data interoperate at Web-scale.
+      * {{{http://json-ld.org/}JSON-LD}}: JSON for Linking Data. a lightweight Linked Data format based on the already successful JSON format and provides a way to help JSON data interoperate at Web-scale.
 
      * {{{http://dev.w3.org/html5/md/}HTML5 Microdata}}: (such as {{{http://schema.org}Schema.org}})
 
@@ -52,7 +52,7 @@ Introduction to Apache Any23
 
     You can <<download>> the latest release from our {{{./download.html}Apache Mirrors}}.
 
-    Previous versions are available from the {{http://archive.apache.org/dist/any23/}Apache Archives site}.
+    Previous versions are available from the {{{http://archive.apache.org/dist/any23/}Apache Archives site}}.
 
 * Documentation Content
 

--- a/src/site/apt/supported-formats.apt
+++ b/src/site/apt/supported-formats.apt
@@ -38,7 +38,7 @@ Supported Formats in Apache Any23
 
    * <<N-Triples>> <<Apache Any23>> fully supports the {{{http://www.w3.org/TR/rdf-testcases/#ntriples}N-Triples}} specification.
 
-   * <<N-Quads>> <<Apache Any23>> fully supports the {{{http://sw.apache.org/2008/07/n-quads/}N-Quads}} specification.
+   * <<N-Quads>> <<Apache Any23>> Version 1.1 supports the 2012 {{{https://web.archive.org/web/20150322024714/http://sw.deri.org/2008/07/n-quads/}N-Quads}} specification (last accessed: 2016-06-17). <<Apache Any23>> Version 1.2 will support the current {{{https://www.w3.org/TR/n-quads/}N-Quads}} specification.
 
    * <<RDF/XML>> <<Apache Any23>> fully supports the {{{http://www.w3.org/TR/rdf-syntax-grammar/}RDF/XML}} specification.
 
@@ -52,7 +52,7 @@ Supported Formats in Apache Any23
 
    * <<N-Triples>> <<Apache Any23>> is able to produce output in {{{http://www.w3.org/TR/rdf-testcases/#ntriples}N-Triples}}.
 
-   * <<N-Quads>> <<Apache Any23>> is able to produce output in {{{http://sw.apache.org/2008/07/n-quads/}N-Quads}}.
+   * <<N-Quads>> <<Apache Any23>> is able to produce output in the 2012 {{{https://web.archive.org/web/20150322024714/http://sw.deri.org/2008/07/n-quads/}N-Quads}} format (last accessed: 2016-06-17). <<Apache Any23>> Version 1.2 will support the current {{{https://www.w3.org/TR/n-quads/}N-Quads}} specification.
 
    * <<RDF/XML>> <<Apache Any23>> is able to produce output in {{{http://www.w3.org/TR/rdf-syntax-grammar/}RDF/XML}}.
 


### PR DESCRIPTION
Documentation updates:
1. supported-formats.apt page: now has working links to N-QUADS documentation; and better information about when current N-QUADS spec will be supported.
2. site/index.apt file was missing a set of matching "{","}" in two places.
