### PR TITLE
ANY23-300: Ignore NetBeans configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.versionsBackup
 **/.externalToolBuilders/
 **/maven-eclipse.xml
 **/any23-site/
+**/nb*.xml


### PR DESCRIPTION
Fix ANY23-300

- Add `**/nb*.xml` pattern into .gitignore to ignore NetBeans configuration files


Signed-off-by: Jacek Grzebyta <grzebyta.dev@gmail.com>