### PR TITLE
ANY23-257 : Add OWL parser support to Any23 via OWLAPI and RDF4J

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -144,6 +144,17 @@
       <groupId>org.semarglproject</groupId>
       <artifactId>semargl-rdf4j</artifactId>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.owlapi</groupId>
+      <artifactId>owlapi-rio</artifactId>
+    </dependency>
+    <!-- Need to include apibinding in runtime scope to allow 
+         dependency injection to work transparently inside of owlapi -->
+    <dependency>
+      <groupId>net.sourceforge.owlapi</groupId>
+      <artifactId>owlapi-apibinding</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <!-- END: RDF4J -->
     
     <!-- BEGIN:  Apache Commons, this version is hosted in the 

--- a/core/src/main/java/org/apache/any23/extractor/rdf/FunctionalSyntaxExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/FunctionalSyntaxExtractor.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.any23.extractor.rdf;
+
+import org.apache.any23.extractor.ExtractionContext;
+import org.apache.any23.extractor.ExtractionResult;
+import org.apache.any23.extractor.ExtractorDescription;
+import org.eclipse.rdf4j.rio.RDFParser;
+
+/**
+ * Concrete implementation of {@link org.apache.any23.extractor.Extractor.ContentExtractor}
+ * handling <a href="https://www.w3.org/TR/owl2-syntax/">OWL2 Functional-Style Syntax</a> format.
+ *
+ * @author Peter Ansell
+ */
+public class FunctionalSyntaxExtractor extends BaseRDFExtractor {
+
+    public FunctionalSyntaxExtractor(boolean verifyDataType, boolean stopAtFirstError) {
+        super(verifyDataType, stopAtFirstError);
+    }
+
+    public FunctionalSyntaxExtractor() {
+        this(false, false);
+    }
+
+    @Override
+    public ExtractorDescription getDescription() {
+        return FunctionalSyntaxExtractorFactory.getDescriptionInstance();
+    }
+
+    @Override
+    protected RDFParser getParser(ExtractionContext extractionContext, ExtractionResult extractionResult) {
+        return RDFParserFactory.getInstance().getFunctionalSyntaxParser(
+                isVerifyDataType(), isStopAtFirstError(), extractionContext, extractionResult
+        );
+    }
+
+}

--- a/core/src/main/java/org/apache/any23/extractor/rdf/FunctionalSyntaxExtractorFactory.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/FunctionalSyntaxExtractorFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.any23.extractor.rdf;
+
+import java.util.Arrays;
+
+import org.apache.any23.extractor.ExtractorDescription;
+import org.apache.any23.extractor.ExtractorFactory;
+import org.apache.any23.extractor.SimpleExtractorFactory;
+import org.apache.any23.rdf.Prefixes;
+import org.semanticweb.owlapi.rio.OWLAPIRDFFormat;
+
+/**
+ * @author Peter Ansell p_ansell@yahoo.com
+ *
+ */
+public class FunctionalSyntaxExtractorFactory extends SimpleExtractorFactory<FunctionalSyntaxExtractor> implements
+        ExtractorFactory<FunctionalSyntaxExtractor> {
+
+    public static final String NAME = "owl-functional";
+    
+    public static final Prefixes PREFIXES = null;
+
+    private static final ExtractorDescription descriptionInstance = new FunctionalSyntaxExtractorFactory();
+    
+    public FunctionalSyntaxExtractorFactory() {
+        super(
+                FunctionalSyntaxExtractorFactory.NAME, 
+                FunctionalSyntaxExtractorFactory.PREFIXES,
+                Arrays.asList(
+                		OWLAPIRDFFormat.OWL_FUNCTIONAL.getDefaultMIMEType()
+                ),
+                "example-functionalsyntax.ofn");
+    }
+    
+    @Override
+    public FunctionalSyntaxExtractor createExtractor() {
+        return new FunctionalSyntaxExtractor();
+    }
+
+    public static ExtractorDescription getDescriptionInstance() {
+        return descriptionInstance;
+    }
+}

--- a/core/src/main/java/org/apache/any23/extractor/rdf/ManchesterSyntaxExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/ManchesterSyntaxExtractor.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.any23.extractor.rdf;
+
+import org.apache.any23.extractor.ExtractionContext;
+import org.apache.any23.extractor.ExtractionResult;
+import org.apache.any23.extractor.ExtractorDescription;
+import org.eclipse.rdf4j.rio.RDFParser;
+
+/**
+ * Concrete implementation of {@link org.apache.any23.extractor.Extractor.ContentExtractor}
+ * handling <a href="http://www.w3.org/TR/owl2-manchester-syntax/">Manchester Syntax</a> format.
+ *
+ * @author Peter Ansell
+ */
+public class ManchesterSyntaxExtractor extends BaseRDFExtractor {
+
+    public ManchesterSyntaxExtractor(boolean verifyDataType, boolean stopAtFirstError) {
+        super(verifyDataType, stopAtFirstError);
+    }
+
+    public ManchesterSyntaxExtractor() {
+        this(false, false);
+    }
+
+    @Override
+    public ExtractorDescription getDescription() {
+        return ManchesterSyntaxExtractorFactory.getDescriptionInstance();
+    }
+
+    @Override
+    protected RDFParser getParser(ExtractionContext extractionContext, ExtractionResult extractionResult) {
+        return RDFParserFactory.getInstance().getManchesterSyntaxParser(
+                isVerifyDataType(), isStopAtFirstError(), extractionContext, extractionResult
+        );
+    }
+
+}

--- a/core/src/main/java/org/apache/any23/extractor/rdf/ManchesterSyntaxExtractorFactory.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/ManchesterSyntaxExtractorFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.any23.extractor.rdf;
+
+import java.util.Arrays;
+
+import org.apache.any23.extractor.ExtractorDescription;
+import org.apache.any23.extractor.ExtractorFactory;
+import org.apache.any23.extractor.SimpleExtractorFactory;
+import org.apache.any23.rdf.Prefixes;
+import org.semanticweb.owlapi.rio.OWLAPIRDFFormat;
+
+/**
+ * @author Peter Ansell p_ansell@yahoo.com
+ *
+ */
+public class ManchesterSyntaxExtractorFactory extends SimpleExtractorFactory<ManchesterSyntaxExtractor> implements
+        ExtractorFactory<ManchesterSyntaxExtractor> {
+
+    public static final String NAME = "owl-manchester";
+    
+    public static final Prefixes PREFIXES = null;
+
+    private static final ExtractorDescription descriptionInstance = new ManchesterSyntaxExtractorFactory();
+    
+    public ManchesterSyntaxExtractorFactory() {
+        super(
+                ManchesterSyntaxExtractorFactory.NAME, 
+                ManchesterSyntaxExtractorFactory.PREFIXES,
+                Arrays.asList(
+                		OWLAPIRDFFormat.MANCHESTER_OWL.getDefaultMIMEType()
+                ),
+                "example-manchestersyntax.omn");
+    }
+    
+    @Override
+    public ManchesterSyntaxExtractor createExtractor() {
+        return new ManchesterSyntaxExtractor();
+    }
+
+    public static ExtractorDescription getDescriptionInstance() {
+        return descriptionInstance;
+    }
+}

--- a/core/src/main/java/org/apache/any23/extractor/rdf/RDFParserFactory.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/RDFParserFactory.java
@@ -31,6 +31,7 @@ import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.RDFaParserSettings;
 import org.eclipse.rdf4j.rio.helpers.RDFaVersion;
 import org.eclipse.rdf4j.rio.turtle.TurtleParser;
+import org.semanticweb.owlapi.rio.OWLAPIRDFFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -178,6 +179,46 @@ public class RDFParserFactory {
             final ExtractionResult extractionResult
     ) {
         final RDFParser parser = Rio.createParser(RDFFormat.NQUADS);
+        configureParser(parser, verifyDataType, stopAtFirstError, extractionContext, extractionResult);
+        return parser;
+    }
+
+    /**
+     * Returns a new instance of a configured ManchesterSyntaxParser.
+     *
+     * @param verifyDataType data verification enable if <code>true</code>.
+     * @param stopAtFirstError the parser stops at first error if <code>true</code>.
+     * @param extractionContext the extraction context where the parser is used.
+     * @param extractionResult the output extraction result.
+     * @return a new instance of a configured Manchester Syntax parser.
+     */
+    public RDFParser getManchesterSyntaxParser(
+            final boolean verifyDataType,
+            final boolean stopAtFirstError,
+            final ExtractionContext extractionContext,
+            final ExtractionResult extractionResult
+    ) {
+        final RDFParser parser = Rio.createParser(OWLAPIRDFFormat.MANCHESTER_OWL);
+        configureParser(parser, verifyDataType, stopAtFirstError, extractionContext, extractionResult);
+        return parser;
+    }
+
+    /**
+     * Returns a new instance of a configured FunctionalSyntaxParser.
+     *
+     * @param verifyDataType data verification enable if <code>true</code>.
+     * @param stopAtFirstError the parser stops at first error if <code>true</code>.
+     * @param extractionContext the extraction context where the parser is used.
+     * @param extractionResult the output extraction result.
+     * @return a new instance of a configured Functional Syntax parser.
+     */
+    public RDFParser getFunctionalSyntaxParser(
+            final boolean verifyDataType,
+            final boolean stopAtFirstError,
+            final ExtractionContext extractionContext,
+            final ExtractionResult extractionResult
+    ) {
+        final RDFParser parser = Rio.createParser(OWLAPIRDFFormat.OWL_FUNCTIONAL);
         configureParser(parser, verifyDataType, stopAtFirstError, extractionContext, extractionResult);
         return parser;
     }

--- a/core/src/main/resources/META-INF/services/org.apache.any23.extractor.ExtractorFactory
+++ b/core/src/main/resources/META-INF/services/org.apache.any23.extractor.ExtractorFactory
@@ -17,7 +17,9 @@ org.apache.any23.extractor.html.SpeciesExtractorFactory
 org.apache.any23.extractor.html.TitleExtractorFactory
 org.apache.any23.extractor.html.XFNExtractorFactory
 org.apache.any23.extractor.microdata.MicrodataExtractorFactory
+org.apache.any23.extractor.rdf.FunctionalSyntaxExtractorFactory
 org.apache.any23.extractor.rdf.JSONLDExtractorFactory
+org.apache.any23.extractor.rdf.ManchesterSyntaxExtractorFactory
 org.apache.any23.extractor.rdf.NQuadsExtractorFactory
 org.apache.any23.extractor.rdf.NTriplesExtractorFactory
 org.apache.any23.extractor.rdf.RDFXMLExtractorFactory

--- a/core/src/main/resources/org/apache/any23/extractor/rdf/example-functionalsyntax.ofn
+++ b/core/src/main/resources/org/apache/any23/extractor/rdf/example-functionalsyntax.ofn
@@ -1,0 +1,5 @@
+Prefix(:=<http://example.org/example-manchestersyntax#>)
+
+Ontology( <http://example.org/example-manchestersyntax>
+  AnnotationAssertion( rdfs:comment :TestIndividual "Test individual is a unique individual" )
+)

--- a/core/src/main/resources/org/apache/any23/extractor/rdf/example-manchestersyntax.omn
+++ b/core/src/main/resources/org/apache/any23/extractor/rdf/example-manchestersyntax.omn
@@ -1,0 +1,5 @@
+Prefix: : <http://example.org/example-manchestersyntax#>
+
+Ontology: <http://example.org/example-manchestersyntax>
+  Individual: TestIndividual
+  Annotations: rdfs:comment "Test individual is a unique individual"

--- a/core/src/test/java/org/apache/any23/extractor/rdf/FunctionalSyntaxExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/rdf/FunctionalSyntaxExtractorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.any23.extractor.rdf;
+
+import org.apache.any23.extractor.ExtractionContext;
+import org.apache.any23.extractor.ExtractionParameters;
+import org.apache.any23.extractor.ExtractionResult;
+import org.apache.any23.extractor.ExtractionResultImpl;
+import org.apache.any23.rdf.RDFUtils;
+import org.apache.any23.writer.RDFXMLWriter;
+import org.apache.any23.writer.TripleHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.eclipse.rdf4j.model.IRI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * Test case for {@link FunctionalSyntaxExtractor}.
+ *
+ * @author Peter Ansell
+ */
+public class FunctionalSyntaxExtractorTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(FunctionalSyntaxExtractorTest.class);
+
+    private FunctionalSyntaxExtractor extractor;
+
+    @Before
+    public void setUp() {
+        extractor = new FunctionalSyntaxExtractor();
+    }
+
+    @After
+    public void tearDown() {
+        extractor = null;
+    }
+
+    @Test
+    public void testExampleFunctionalSyntax()
+    		throws Exception {
+        final IRI uri = RDFUtils.iri("http://example.org/example-functionalsyntax.ofn");
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final TripleHandler th = new RDFXMLWriter(baos);
+        final ExtractionContext extractionContext = new ExtractionContext("owl-functionalsyntax-extractor", uri);
+        final ExtractionResult result = new ExtractionResultImpl(extractionContext, extractor, th);
+        extractor.setStopAtFirstError(false);
+        try {
+            extractor.run(
+                    ExtractionParameters.newDefault(),
+                    extractionContext,
+                    this.getClass().getResourceAsStream("/text/owl-functional/example-functionalsyntax.ofn"),
+                    result
+            );
+        } finally {
+            logger.debug(baos.toString());
+            th.close();
+            result.close();
+        }
+    }
+
+}

--- a/core/src/test/java/org/apache/any23/extractor/rdf/ManchesterSyntaxExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/rdf/ManchesterSyntaxExtractorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.any23.extractor.rdf;
+
+import org.apache.any23.extractor.ExtractionContext;
+import org.apache.any23.extractor.ExtractionParameters;
+import org.apache.any23.extractor.ExtractionResult;
+import org.apache.any23.extractor.ExtractionResultImpl;
+import org.apache.any23.rdf.RDFUtils;
+import org.apache.any23.writer.RDFXMLWriter;
+import org.apache.any23.writer.TripleHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.eclipse.rdf4j.model.IRI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * Test case for {@link ManchesterSyntaxExtractor}.
+ *
+ * @author Peter Ansell
+ */
+public class ManchesterSyntaxExtractorTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(ManchesterSyntaxExtractorTest.class);
+
+    private ManchesterSyntaxExtractor extractor;
+
+    @Before
+    public void setUp() {
+        extractor = new ManchesterSyntaxExtractor();
+    }
+
+    @After
+    public void tearDown() {
+        extractor = null;
+    }
+
+    @Test
+    public void testExampleManchesterSyntax()
+    		throws Exception {
+        final IRI uri = RDFUtils.iri("http://example.org/example-manchestersyntax.omn");
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final TripleHandler th = new RDFXMLWriter(baos);
+        final ExtractionContext extractionContext = new ExtractionContext("owl-manchestersyntax-extractor", uri);
+        final ExtractionResult result = new ExtractionResultImpl(extractionContext, extractor, th);
+        extractor.setStopAtFirstError(false);
+        try {
+            extractor.run(
+                    ExtractionParameters.newDefault(),
+                    extractionContext,
+                    this.getClass().getResourceAsStream("/text/owl-manchester/example-manchestersyntax.omn"),
+                    result
+            );
+        } finally {
+            logger.debug(baos.toString());
+            th.close();
+            result.close();
+        }
+    }
+
+}

--- a/plugins/integration-test/src/test/java/org/apache/any23/plugin/PluginIT.java
+++ b/plugins/integration-test/src/test/java/org/apache/any23/plugin/PluginIT.java
@@ -40,8 +40,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class PluginIT {
 
-    //TODO reduced from 31 to 28 within ANY23-276
-    private static final int NUM_OF_EXTRACTORS = 29;
+    private static final int NUM_OF_EXTRACTORS = 31;
 
     private static final String PLUGIN_DIR = "target/plugins-build/";
 

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,7 @@
 
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.6</httpcore.version>
+    <owlapi.version>5.1.0</owlapi.version>
     <poi.version>3.16</poi.version>
     <rdf4j.version>2.2.2</rdf4j.version>
     <semargl.version>0.7</semargl.version>
@@ -476,6 +477,34 @@
         <version>${rdf4j.version}</version>
       </dependency>
       <!-- END: Misc -->
+
+      <!-- BEGIN: OWLAPI -->
+      <dependency>
+        <groupId>net.sourceforge.owlapi</groupId>
+        <artifactId>owlapi-api</artifactId>
+        <version>${owlapi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.sourceforge.owlapi</groupId>
+        <artifactId>owlapi-impl</artifactId>
+        <version>${owlapi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.sourceforge.owlapi</groupId>
+        <artifactId>owlapi-rio</artifactId>
+        <version>${owlapi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.sourceforge.owlapi</groupId>
+        <artifactId>owlapi-parsers</artifactId>
+        <version>${owlapi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.sourceforge.owlapi</groupId>
+        <artifactId>owlapi-apibinding</artifactId>
+        <version>${owlapi.version}</version>
+      </dependency>
+      <!-- END: OWLAPI -->
 
       <!-- BEGIN:  Apache Commons -->
       <dependency>

--- a/test-resources/src/test/resources/text/owl-functional/example-functionalsyntax.ofn
+++ b/test-resources/src/test/resources/text/owl-functional/example-functionalsyntax.ofn
@@ -1,0 +1,5 @@
+Prefix(:=<http://example.org/example-manchestersyntax#>)
+
+Ontology( <http://example.org/example-manchestersyntax>
+  AnnotationAssertion( rdfs:comment :TestIndividual "Test individual is a unique individual" )
+)

--- a/test-resources/src/test/resources/text/owl-manchester/example-manchestersyntax.omn
+++ b/test-resources/src/test/resources/text/owl-manchester/example-manchestersyntax.omn
@@ -1,0 +1,5 @@
+Prefix: : <http://example.org/example-manchestersyntax#>
+
+Ontology: <http://example.org/example-manchestersyntax>
+  Individual: TestIndividual
+  Annotations: rdfs:comment "Test individual is a unique individual"


### PR DESCRIPTION
Adds OWL parsing support through OWLAPI via RDF4J Rio for Manchester Syntax and Functional Syntax.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>