### PR TITLE
Support attribute content on all fields.

### DIFF
--- a/core/src/main/java/org/apache/any23/extractor/microdata/MicrodataParser.java
+++ b/core/src/main/java/org/apache/any23/extractor/microdata/MicrodataParser.java
@@ -309,7 +309,7 @@ public class MicrodataParser {
         if(itemPropValue != null) return itemPropValue;
 
         final String nodeName = node.getNodeName().toLowerCase();
-        if ("meta".equals(nodeName)) {
+        if (DomUtils.hasAttribute(node, "content")) {
             return new ItemPropValue(DomUtils.readAttribute(node, "content"), ItemPropValue.Type.Plain);
         }
 


### PR DESCRIPTION
<sometag content="something" /> should be considered, regardless if `content` is not a valid
attribute of `sometag`.

The specification for microdata[1] details that an elements content attribute should be considered
before text content.

Any23 doesn't currently do this, it only considers `content` for `meta` tags which is the only
HTML tag which is suppose to have a `content` but not all sites follow HTML specifications.

Updating the microdata parser to be able to get `content` from any element should it exist.

[1] https://www.w3.org/TR/microdata/#values

Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>