### PR TITLE
ANY23-140 - Revise Any23 tests to remove fetching of web content

### DIFF
--- a/cli/src/test/java/org/apache/any23/cli/MicrodataParserTest.java
+++ b/cli/src/test/java/org/apache/any23/cli/MicrodataParserTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.any23.cli;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -35,12 +34,10 @@ public class MicrodataParserTest extends ToolTestBase {
     public void testRunOnFile() throws Exception {
         runToolCheckExit0("file:"+copyResourceToTempFile("/microdata/microdata-nested.html").getAbsolutePath());
     }
-    
-    @Ignore("ANY23-140 - Revise Any23 tests to remove fetching of web content")
+
     @Test
     public void testRunOnHTTPResource() throws Exception {
         runToolCheckExit0("http://www.imdb.com/title/tt1375666/");
     }
-    
 
 }

--- a/core/src/test/java/org/apache/any23/Any23Test.java
+++ b/core/src/test/java/org/apache/any23/Any23Test.java
@@ -45,7 +45,6 @@ import org.apache.any23.writer.RepositoryWriter;
 import org.apache.any23.writer.TripleHandler;
 import org.apache.any23.writer.TripleHandlerException;
 import org.apache.commons.io.IOUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.repository.Repository;
@@ -207,7 +206,6 @@ public class Any23Test extends Any23OnlineTestBase {
      * @throws IOException
      * @throws org.apache.any23.extractor.ExtractionException
      */
-    @Ignore("ANY23-140 - Revise Any23 tests to remove fetching of web content")
     @Test
     public void testDemoCodeSnippet2() throws Exception {
         assumeOnlineAllowed();
@@ -299,7 +297,6 @@ public class Any23Test extends Any23OnlineTestBase {
      * @throws URISyntaxException
      * @throws ExtractionException
      */
-    @Ignore("ANY23-140 - Revise Any23 tests to remove fetching of web content")
     @Test
     public void testGZippedContent() throws IOException, URISyntaxException,
             ExtractionException {
@@ -449,7 +446,6 @@ public class Any23Test extends Any23OnlineTestBase {
      * @throws IOException
      * @throws ExtractionException
      */
-    @Ignore("ANY23-140 - Revise Any23 tests to remove fetching of web content")
     @Test
     public void testXMLMimeTypeManagementViaURL() throws IOException,
             ExtractionException {
@@ -464,7 +460,6 @@ public class Any23Test extends Any23OnlineTestBase {
         Assert.assertEquals(0, cth.getCount());
     }
 
-    @Ignore("ANY23-140 - Revise Any23 tests to remove fetching of web content")
     @Test
     public void testBlankNodesViaURL() throws IOException, ExtractionException {
         assumeOnlineAllowed();
@@ -477,7 +472,6 @@ public class Any23Test extends Any23OnlineTestBase {
         Assert.assertTrue(report.hasMatchingExtractors());
     }
 
-    @Ignore("Itemscope parsing issue")
     @Test
     public void testMicrodataSupport() throws Exception {
         final String htmlWithMicrodata = IOUtils.toString(this.getClass()

--- a/plugins/basic-crawler/src/test/java/org/apache/any23/cli/CrawlerTest.java
+++ b/plugins/basic-crawler/src/test/java/org/apache/any23/cli/CrawlerTest.java
@@ -20,7 +20,6 @@ package org.apache.any23.cli;
 import org.apache.any23.Any23OnlineTestBase;
 import org.apache.any23.rdf.RDFUtils;
 import org.apache.any23.util.FileUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -47,7 +46,6 @@ public class CrawlerTest extends Any23OnlineTestBase {
 
     public static final Logger logger = LoggerFactory.getLogger(CrawlerTest.class);
 
-    @Ignore("ANY23-140 - Revise Any23 tests to remove fetching of web content")
     @Test
     public void testCLI() throws IOException, RDFHandlerException, RDFParseException {
         assumeOnlineAllowed();


### PR DESCRIPTION
This issue re-enables the 'online' tests as essentially the jsonld tests require fetching of Web content anyways.