### PR TITLE
Fix HTTP repository link: change to HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -604,7 +604,7 @@
   <repositories>
     <repository>
       <id>any23-repository-external</id>
-      <url>http://svn.apache.org/repos/asf/any23/repo-ext/</url>
+      <url>https://svn.apache.org/repos/asf/any23/repo-ext/</url>
     </repository>
     <repository>
       <id>sonatype-snapshots</id>


### PR DESCRIPTION
The any23-repository-external repository will currently cause setups forbidding fetching packages over plain HTTP to error. Notably this includes Leiningen. Luckily we can just use the HTTPS url instead.