### PR TITLE
ANY23-327 Change log level to debug for RDFUtils.isAbsoluteIRI()

### DIFF
--- a/core/src/main/java/org/apache/any23/rdf/RDFUtils.java
+++ b/core/src/main/java/org/apache/any23/rdf/RDFUtils.java
@@ -528,10 +528,10 @@ public class RDFUtils {
             new java.net.URI(href.trim());
             return true;
         } catch (IllegalArgumentException e) {
-            LOG.error("Error processing href: {}", href, e);
+            LOG.debug("Error processing href: {}", href, e);
             return false;
         } catch (URISyntaxException e) {
-            LOG.error("Error interpreting href: {} as URI.", href, e);
+            LOG.debug("Error interpreting href: {} as URI.", href, e);
             return false;
         }
     }


### PR DESCRIPTION
No need to see a stack trace every time `isAbsoluteIRI` returns `false`.