### PR TITLE
ANY23-328 Strip comments from json-ld to make parsing more lenient

### DIFF
--- a/core/src/main/java/org/apache/any23/extractor/html/EmbeddedJSONLDExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/html/EmbeddedJSONLDExtractor.java
@@ -27,6 +27,7 @@ import org.apache.any23.extractor.rdf.JSONLDExtractor;
 import org.apache.any23.extractor.rdf.JSONLDExtractorFactory;
 import org.apache.any23.rdf.RDFUtils;
 import org.apache.any23.vocab.SINDICE;
+import org.apache.commons.io.IOUtils;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.w3c.dom.Document;
@@ -34,6 +35,7 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -145,8 +147,7 @@ public class EmbeddedJSONLDExtractor implements Extractor.TagSoupDOMExtractor {
       for (int i = 0; i < attributes.getLength(); i++) {
         if ("application/ld+json".equalsIgnoreCase(attributes.item(i).getTextContent())) {
           extractor.run(extractionParameters, extractionContext,
-                  DomUtils.nodeToInputStream(jsonldNode
-                          .getFirstChild()), out);
+                  IOUtils.toInputStream(jsonldNode.getTextContent(), StandardCharsets.UTF_8), out);
         }
       }
       Node nameAttribute = attributes.getNamedItem("name");

--- a/core/src/test/java/org/apache/any23/extractor/html/EmbeddedJSONLDExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/html/EmbeddedJSONLDExtractorTest.java
@@ -53,6 +53,13 @@ public class EmbeddedJSONLDExtractorTest extends AbstractExtractorTestCase {
 		assertStatementsSize(null, null, null, 7);
 	}
 
+	@Test
+	public void testJSONLDCommentStripping() throws Exception {
+		assertExtract("/html/html-jsonld-strip-comments.html");
+		assertModelNotEmpty();
+		assertStatementsSize(null, null, null, 3);
+	}
+
 	@Override
 	protected ExtractorFactory<?> getExtractorFactory() {
 		return new EmbeddedJSONLDExtractorFactory();

--- a/test-resources/src/test/resources/html/html-jsonld-strip-comments.html
+++ b/test-resources/src/test/resources/html/html-jsonld-strip-comments.html
@@ -1,0 +1,51 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html>
+<head>
+    <title>Hello World!</title>
+    <meta name="title" content="Embedded JSONLD extractor"/>
+    <!-- As per spec in http://www.w3.org/TR/json-ld/#embedding-json-ld-in-html-documents -->
+    <script type="application/ld+json">
+    /* first
+    multiline comment
+    # */
+    # for funsies -- although this one won't occur in html
+    //first single line comment!
+    <![CDATA[
+    //second single line comment
+    /* //**second multiline comment* */ //third single line comment
+    [{
+      "@context": "http://json-ld.org/contexts/person.jsonld",
+      "@id": "http://dbpedia.org/resource/Robert_Millar",
+      //the above urls should test that comments inside quotes are *not* stripped
+      "@type": "Person",]]> /*
+       multiline comment
+      inside json */ "name": <![CDATA["Robert\" Millar", //comment
+      #comment
+      "born": "1958-09-13T00:00:00"
+    }]]]> ///some more commenting
+    /* a
+    final
+    multiline
+    comment*/ //a final single line comment
+    </script>
+
+
+</head>
+<h1>Embedded JSONLD Extractor</h1>
+<p>It extracts only the embedded JSON-LD elements.
+</html>


### PR DESCRIPTION
I stripped single-line and multi-line comments from json-ld content, as well as CDATA markers.

Also added a test case.

`mvn clean install` -> All tests pass.