### PR TITLE
ANY23-323 Update Eclipse RDF4J version to 2.3.0

### DIFF
--- a/core/src/main/java/org/apache/any23/extractor/rdf/BaseRDFExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/BaseRDFExtractor.java
@@ -117,8 +117,10 @@ public abstract class BaseRDFExtractor implements Extractor.ContentExtractor {
             parser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_DATATYPE_VALUES);
             parser.getParserConfig().set(BasicParserSettings.NORMALIZE_DATATYPE_VALUES, false);
             parser.getParserConfig().addNonFatalError(BasicParserSettings.NORMALIZE_DATATYPE_VALUES);
-            //ByteBuffer seems to represent incorrect content. Need to make sure it is the content
-            //of the <script> node and not anything else!
+            parser.getParserConfig().set(BasicParserSettings.VERIFY_RELATIVE_URIS, true);
+            parser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_RELATIVE_URIS);
+
+
             RDFFormat format = parser.getRDFFormat();
             String iri = extractionContext.getDocumentIRI().stringValue();
 

--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
     <httpcore.version>4.4.6</httpcore.version>
     <owlapi.version>5.1.3</owlapi.version>
     <poi.version>3.16</poi.version>
-    <rdf4j.version>2.2.4</rdf4j.version>
+    <rdf4j.version>2.3.0</rdf4j.version>
     <semargl.version>0.7</semargl.version>
     <slf4j.logger.version>1.7.25</slf4j.logger.version>
     <tika.version>1.17</tika.version>


### PR DESCRIPTION
I also had to add `BasicParserSettings.VERIFY_RELATIVE_URIS` as a non-fatal error, due to differences in the ways that version 2.2.4 and 2.3.0 calculated whether a URI is *opaque*:

2.2.4 called any URI with a null path opaque (which could never happen)

2.3.0 called a URI opaque if it had a non-null scheme and its path did not begin with "/"

Without classifying the above error as non-fatal, errors occurred in the turtle parser test. Since the document IRI did not end with "/", it was classified as "opaque" by version 2.3.0, hence attempting to resolve a relative IRI against it resulted in an error.

mvn clean test -> all tests pass