### PR TITLE
ANY23-348 handle malformed microdata types gracefully

### DIFF
--- a/core/src/main/java/org/apache/any23/extractor/microdata/ItemScope.java
+++ b/core/src/main/java/org/apache/any23/extractor/microdata/ItemScope.java
@@ -17,6 +17,9 @@
 
 package org.apache.any23.extractor.microdata;
 
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.rdf4j.common.net.ParsedIRI;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -69,20 +72,29 @@ public class ItemScope extends Item {
      * @param itemId    <i>itemscope</i> id. Can be <code>null</code>.
      */
     public ItemScope(String xpath, ItemProp[] itemProps, String id, String[] refs, String type, String itemId) {
+        this(xpath, itemProps, id, refs, stringToUrl(type), itemId);
+    }
+
+    static URL stringToUrl(String type) {
+        if (StringUtils.isNotBlank(type)) {
+            try {
+                return new URL(ParsedIRI.create(type.trim()).toString());
+            } catch (MalformedURLException murle) {
+                throw new IllegalArgumentException("Invalid type '" + type + "', must be a valid URL.");
+            }
+        } else {
+            return null;
+        }
+    }
+
+    ItemScope(String xpath, ItemProp[] itemProps, String id, String[] refs, URL type, String itemId) {
         super(xpath);
 
         if (itemProps == null) {
             throw new NullPointerException("itemProps list cannot be null.");
         }
-        if (type != null) {
-            try {
-                this.type = new URL(type);
-            } catch (MalformedURLException murle) {
-                throw new IllegalArgumentException("Invalid type '" + type + "', must be a valid URL.");
-            }
-        } else {
-            this.type = null;
-        }
+
+        this.type = type;
         this.id = id;
         this.refs = refs;
         this.itemId = itemId;

--- a/core/src/test/java/org/apache/any23/extractor/microdata/MicrodataExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/microdata/MicrodataExtractorTest.java
@@ -192,6 +192,11 @@ public class MicrodataExtractorTest extends AbstractExtractorTestCase {
         assertContains(RDFUtils.iri("http://schema.org/telephone"), RDFUtils.iri("tel:(909)%20484-2020"));
     }
 
+    @Test
+    public void testBadTypes() throws IOException {
+        extractAndVerifyAgainstNQuads("microdata-bad-types.html", "microdata-bad-types-expected.nquads");
+    }
+
     private void extractAndVerifyAgainstNQuads(String actual, String expected)
     throws RepositoryException, RDFHandlerException, IOException, RDFParseException {
         assertExtract("/microdata/" + actual);

--- a/test-resources/src/test/resources/microdata/microdata-bad-types-expected.nquads
+++ b/test-resources/src/test/resources/microdata/microdata-bad-types-expected.nquads
@@ -1,0 +1,26 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+_:node1cdqplnvmx2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/animals#american%20shorthair> <http://bob.example.com/> .
+_:node1cdqplnvmx2 <http://example.org/animals#img> <http://bob.example.com/hedral.jpeg> <http://bob.example.com/> .
+_:node1cdqplnvmx2 <http://example.org/animals#name> "Hedral" <http://bob.example.com/> .
+_:node1cdqplnvmx2 <http://example.org/animals#desc> "Hedral is a male american domestic shorthair, with a fluffy black fur with white paws and belly." <http://bob.example.com/> .
+<http://bob.example.com/> <http://www.w3.org/1999/xhtml/microdata#item> _:node1cdqplnvmx2 <http://bob.example.com/> .
+<urn:isbn:0-330-34032-8> <http://schema.org/author> "Peter F. Hamilton\n    " <http://bob.example.com/> .
+<urn:isbn:0-330-34032-8> <http://schema.org/title> "The Reality Dysfunction\n    " <http://bob.example.com/> .
+<urn:isbn:0-330-34032-8> <http://schema.org/pubdate> "1996-01-26"^^<http://www.w3.org/2001/XMLSchema#date> <http://bob.example.com/> .
+<http://bob.example.com/> <http://www.w3.org/1999/xhtml/microdata#item> <urn:isbn:0-330-34032-8> <http://bob.example.com/> .

--- a/test-resources/src/test/resources/microdata/microdata-bad-types.html
+++ b/test-resources/src/test/resources/microdata/microdata-bad-types.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html>
+<head></head>
+<body>
+
+<!--  result9 -->
+<section itemscope itemtype=" http://example.org/animals#american shorthair ">
+    <h1 itemprop="name">Hedral</h1>
+    <p itemprop="desc">Hedral is a male american domestic shorthair, with a fluffy black fur with white paws and belly.</p>
+    <img itemprop="img" src="hedral.jpeg" alt=""
+         title="Hedral, age 18 months">
+</section>
+
+<!--  result10 -->
+<dl itemscope itemtype=""
+    itemid="urn:isbn:0-330-34032-8">
+    <dt>Title
+    <dd itemprop="title">The Reality Dysfunction
+    <dt>Author
+    <dd itemprop="author">Peter F. Hamilton
+    <dt>Publication date
+    <dd>
+        <time itemprop="pubdate" datetime="1996-01-26">26 January
+            1996</time>
+</dl>
+
+</body>
+</html>

--- a/test-resources/src/test/resources/microdata/tel-test.html
+++ b/test-resources/src/test/resources/microdata/tel-test.html
@@ -1,3 +1,20 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Original page source: http://clubzone.com/ontario-los-angeles/places/ -->
 
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
I did two things: 

(1) Treat blank microdata types as if they were null

(2) For other varieties of malformed microdata types, first attempt to fix them by trimming leading & trailing whitespaces and url-encoding illegal characters. If that fails, then only throw a fatal error if the microdata parser error mode is set to STOP_AT_FIRST_ERROR; otherwise, add the error to the error list, treat the type as if it were null, and continue parsing.

mvn clean test -> all tests pass

@lewismc what do you think?