### PR TITLE
ANY23-351 fixed NullPointerException in HCardExtractor

### DIFF
--- a/core/src/main/java/org/apache/any23/extractor/html/HCardExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/html/HCardExtractor.java
@@ -89,6 +89,8 @@ public class HCardExtractor extends EntityBasedMicroformatExtractor {
             current.getAttributes().removeNamedItem("class");
             ArrayList<TextField> res = new ArrayList<TextField>();
             HTMLDocument.readUrlField(res, current);
+            if (res.isEmpty())
+                continue;
             TextField id = res.get(0);
             if (null == id)
                 continue;

--- a/core/src/test/java/org/apache/any23/extractor/html/HCardExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/html/HCardExtractorTest.java
@@ -48,6 +48,15 @@ public class HCardExtractorTest extends AbstractExtractorTestCase {
     return new HCardExtractorFactory();
   }
 
+
+  @Test
+  public void testNoNullPointers() {
+    //see https://issues.apache.org/jira/browse/ANY23-351
+    assertExtract("/microformats/hcard/null-pointer.html");
+    assertContains(vVCARD.logo, RDFUtils.iri("http://cambridgewi.com/wp-content/uploads/connections-images/dean-bluhm/VillagePharmacy-e04951b21968ae4d9fd04cb14ce08ade.jpg"));
+    assertContains(vVCARD.email, RDFUtils.iri("mailto:bluhmrph@yahoo.com"));
+  }
+
   @Test
   public void testEMailNotUriReal() throws Exception {
     assertExtract("/microformats/hcard/17-email-not-uri.html");

--- a/test-resources/src/test/resources/microformats/hcard/null-pointer.html
+++ b/test-resources/src/test/resources/microformats/hcard/null-pointer.html
@@ -1,0 +1,625 @@
+<!DOCTYPE html>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!-- original page source: https://cambridgewi.com/make-cambridge-home/char/V/ -->
+
+<html class="no-js" lang="en-US">
+
+<head>
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Make Cambridge Home | Cambridge, Wisconsin Chamber Of Commerce</title>
+    <link rel="pingback" href="https://cambridgewi.com/xmlrpc.php"><meta property="og:title" content="Make Cambridge Home" />
+    <meta property="og:description" content="" />
+    <link rel='dns-prefetch' href='//s.w.org' />
+    <link rel="alternate" type="application/rss+xml" title="Cambridge, Wisconsin Chamber Of Commerce &raquo; Feed" href="https://cambridgewi.com/feed/" />
+    <link rel="alternate" type="application/rss+xml" title="Cambridge, Wisconsin Chamber Of Commerce &raquo; Comments Feed" href="https://cambridgewi.com/comments/feed/" />
+    <script type="text/javascript">
+			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/2.4\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/2.4\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/cambridgewi.com\/wp-includes\/js\/wp-emoji-release.min.js?ver=4.9.6"}};
+			!function(a,b,c){function d(a,b){var c=String.fromCharCode;l.clearRect(0,0,k.width,k.height),l.fillText(c.apply(this,a),0,0);var d=k.toDataURL();l.clearRect(0,0,k.width,k.height),l.fillText(c.apply(this,b),0,0);var e=k.toDataURL();return d===e}function e(a){var b;if(!l||!l.fillText)return!1;switch(l.textBaseline="top",l.font="600 32px Arial",a){case"flag":return!(b=d([55356,56826,55356,56819],[55356,56826,8203,55356,56819]))&&(b=d([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]),!b);case"emoji":return b=d([55357,56692,8205,9792,65039],[55357,56692,8203,9792,65039]),!b}return!1}function f(a){var c=b.createElement("script");c.src=a,c.defer=c.type="text/javascript",b.getElementsByTagName("head")[0].appendChild(c)}var g,h,i,j,k=b.createElement("canvas"),l=k.getContext&&k.getContext("2d");for(j=Array("flag","emoji"),c.supports={everything:!0,everythingExceptFlag:!0},i=0;i<j.length;i++)c.supports[j[i]]=e(j[i]),c.supports.everything=c.supports.everything&&c.supports[j[i]],"flag"!==j[i]&&(c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&c.supports[j[i]]);c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&!c.supports.flag,c.DOMReady=!1,c.readyCallback=function(){c.DOMReady=!0},c.supports.everything||(h=function(){c.readyCallback()},b.addEventListener?(b.addEventListener("DOMContentLoaded",h,!1),a.addEventListener("load",h,!1)):(a.attachEvent("onload",h),b.attachEvent("onreadystatechange",function(){"complete"===b.readyState&&c.readyCallback()})),g=c.source||{},g.concatemoji?f(g.concatemoji):g.wpemoji&&g.twemoji&&(f(g.twemoji),f(g.wpemoji)))}(window,document,window._wpemojiSettings);
+		</script>
+    <style type="text/css">
+img.wp-smiley,
+img.emoji {
+	display: inline !important;
+	border: none !important;
+	box-shadow: none !important;
+	height: 1em !important;
+	width: 1em !important;
+	margin: 0 .07em !important;
+	vertical-align: -0.1em !important;
+	background: none !important;
+	padding: 0 !important;
+}
+</style>
+    <link rel='stylesheet' id='ecwid-css-css'  href='https://cambridgewi.com/wp-content/plugins/ecwid-shopping-cart/css/frontend.css?ver=6.1.1' type='text/css' media='all' />
+    <link rel='stylesheet' id='cn-widgets-css'  href='//cambridgewi.com/wp-content/plugins/connections-widgets/assets/css/cn-widgets.min.css?ver=4.9.6' type='text/css' media='all' />
+    <link rel='stylesheet' id='x-stack-css'  href='https://cambridgewi.com/wp-content/themes/x/framework/dist/css/site/stacks/integrity-light.css?ver=6.1.6' type='text/css' media='all' />
+    <link rel='stylesheet' id='x-cranium-migration-css'  href='https://cambridgewi.com/wp-content/themes/x/framework/legacy/cranium/dist/css/site/integrity-light.css?ver=6.1.6' type='text/css' media='all' />
+    <link rel='stylesheet' id='cn-public-css'  href='https://cambridgewi.com/wp-content/plugins/connections/assets/css/cn-user.min.css?ver=8.21' type='text/css' media='all' />
+    <link rel='stylesheet' id='cnt-cmap-css'  href='//cambridgewi.com/wp-content/plugins/connections-cmap/cmap.min.css?ver=5.3' type='text/css' media='all' />
+    <style id='cnt-cmap-inline-css' type='text/css'>
+/* cMap Template Customizer Custom Styles */
+#cn-cmap .cn-list-row h3 .fn,
+#cn-cmap .cn-list-row-alternate h3 .fn {
+	color: #000;
+}
+#cn-cmap .cn-list-row,
+#cn-cmap .cn-list-row-alternate {
+	color: #000;
+}
+#cn-cmap span.contact-label,
+#cn-cmap span.cn-relation-label,
+#cn-cmap span.adr span.address-name,
+#cn-cmap span.tel span.phone-name,
+#cn-cmap span.email span.email-name,
+#cn-cmap span.im-network span.im-name,
+#cn-cmap span.link span.link-name,
+#cn-cmap span.cn-date span.date-name {
+	color: #000;
+}
+#cn-cmap .cn-list-row a,
+#cn-cmap .cn-list-row a:visited,
+#cn-cmap .cn-list-row-alternate a,
+#cn-cmap .cn-list-row-alternate a:visited {
+	color: #000;
+}
+#cn-cmap .cn-content-tray .cn-bio-tray,
+#cn-cmap .cn-content-tray .cn-note-tray,
+#cn-cmap .cn-content-tray .cn-gmap {
+	background-color: #ffffff;
+}
+#cn-cmap .cn-content-tray {
+	color: #000;
+}
+#cn-cmap .cn-content-tray a,
+#cn-cmap .cn-content-tray a:visited {
+	color: #000;
+}
+</style>
+    <link rel='stylesheet' id='rhc-print-css-css'  href='https://cambridgewi.com/wp-content/plugins/calendarize-it/css/print.css?ver=1.0.2' type='text/css' media='all' />
+    <link rel='stylesheet' id='calendarizeit-css'  href='https://cambridgewi.com/wp-content/plugins/calendarize-it/css/frontend.min.css?ver=4.0.8.5' type='text/css' media='all' />
+    <link rel='stylesheet' id='rhc-last-minue-css'  href='https://cambridgewi.com/wp-content/plugins/calendarize-it/css/last_minute_fixes.css?ver=1.0.11' type='text/css' media='all' />
+    <link rel='stylesheet' id='cn-chosen-css'  href='//cambridgewi.com/wp-content/plugins/connections/vendor/chosen/chosen.min.css?ver=1.7' type='text/css' media='all' />
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/widget.min.js?ver=1.11.4'></script>
+    <script type='text/javascript'>
+/* <![CDATA[ */
+var ecwidParams = {"useJsApiToOpenStoreCategoriesPages":""};
+/* ]]> */
+</script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-content/plugins/ecwid-shopping-cart/js/frontend.js?ver=6.1.1'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-content/plugins/cornerstone/assets/dist/js/site/cs-head.js?ver=3.1.6'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-content/plugins/calendarize-it/js/bootstrap.min.js?ver=3.0.0'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-content/plugins/calendarize-it/js/bootstrap-select.js?ver=1.0.2'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/core.min.js?ver=1.11.4'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/accordion.min.js?ver=1.11.4'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/mouse.min.js?ver=1.11.4'></script>
+    <script type='text/javascript'>
+/* <![CDATA[ */
+var slider_params = {"min":"0","max":"10"};
+/* ]]> */
+</script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/slider.min.js?ver=1.11.4'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/resizable.min.js?ver=1.11.4'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/draggable.min.js?ver=1.11.4'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/button.min.js?ver=1.11.4'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/position.min.js?ver=1.11.4'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/dialog.min.js?ver=1.11.4'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/tabs.min.js?ver=1.11.4'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/sortable.min.js?ver=1.11.4'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/droppable.min.js?ver=1.11.4'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/datepicker.min.js?ver=1.11.4'></script>
+    <script type='text/javascript'>
+jQuery(document).ready(function(jQuery){jQuery.datepicker.setDefaults({"closeText":"Close","currentText":"Today","monthNames":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthNamesShort":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"nextText":"Next","prevText":"Previous","dayNames":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"dayNamesShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"dayNamesMin":["S","M","T","W","T","F","S"],"dateFormat":"MM d, yy","firstDay":0,"isRTL":false});});
+</script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/menu.min.js?ver=1.11.4'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/wp-a11y.min.js?ver=4.9.6'></script>
+    <script type='text/javascript'>
+/* <![CDATA[ */
+var uiAutocompleteL10n = {"noResults":"No results found.","oneResult":"1 result found. Use up and down arrow keys to navigate.","manyResults":"%d results found. Use up and down arrow keys to navigate.","itemSelected":"Item selected."};
+/* ]]> */
+</script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/ui/autocomplete.min.js?ver=1.11.4'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-content/plugins/calendarize-it/js/deprecated.js?ver=bundled-jquery-ui'></script>
+    <script type='text/javascript'>
+/* <![CDATA[ */
+var RHC = {"ajaxurl":"https:\/\/cambridgewi.com\/","mobile_width":"480","last_modified":"a6ae0943ae74a4aaa6ed88e810c3bf2a","tooltip_details":[],"visibility_check":"","gmt_offset":"-7","disable_event_link":"0"};
+/* ]]> */
+</script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-content/plugins/calendarize-it/js/frontend.min.js?ver=4.6.4.5'></script>
+    <script type='text/javascript' src='https://maps.google.com/maps/api/js?libraries=places&#038;ver=3.0'></script>
+    <script type='text/javascript' src='https://cambridgewi.com/wp-content/plugins/calendarize-it/js/rhc_gmap3.js?ver=1.0.1'></script>
+    <link rel='https://api.w.org/' href='https://cambridgewi.com/wp-json/' />
+    <link rel="canonical" href="https://cambridgewi.com/make-cambridge-home/" />
+    <link rel='shortlink' href='https://cambridgewi.com/?p=198' />
+    <link rel="alternate" type="application/json+oembed" href="https://cambridgewi.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fcambridgewi.com%2Fmake-cambridge-home%2F" />
+    <link rel="alternate" type="text/xml+oembed" href="https://cambridgewi.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fcambridgewi.com%2Fmake-cambridge-home%2F&#038;format=xml" />
+    <meta http-equiv="x-dns-prefetch-control" content="on">
+    <link href="https://d201eyh6wia12q.cloudfront.net" rel="preconnect" crossorigin />
+    <link href="https://d3fi9i0jj23cau.cloudfront.net" rel="preconnect" crossorigin />
+    <link href="https://dqzrr9k4bjpzk.cloudfront.net" rel="preconnect" crossorigin />
+    <link href="https://ecwid-static-ru.gcdn.co" rel="preconnect" crossorigin />
+    <link href="https://ecwid-images-ru.gcdn.co" rel="preconnect" crossorigin />
+    <link href="https://app.ecwid.com" rel="preconnect" crossorigin />
+    <link rel="prefetch" href="https://app.ecwid.com/script.js?9380027&data_platform=wporg" />
+    <link rel="prerender" href="https://cambridgewi.com/store/" />
+    <script type="text/javascript">
+window.ec = window.ec || Object();
+window.ec.config = window.ec.config || Object();
+window.ec.config.enable_canonical_urls = true;
+window.ec.config.chameleon = window.ec.config.chameleon || Object();
+window.ec.config.chameleon.font = "auto";
+window.ec.config.chameleon.colors = "auto";</script><script data-cfasync="false" type="text/javascript">var ecwid_ProductBrowserURL = "https://cambridgewi.com/store/";</script><meta property="og:site_name" content="Cambridge, Wisconsin Chamber Of Commerce"><meta property="og:title" content="Make Cambridge Home"><meta property="og:description" content="We find that some visitors fall in love with our village and want to make Cambridge their home.  With top-ranked schools, sparkling Lake Ripley, a playful spirit and ideal location between Madison and Milwaukee, we’re&hellip;"><meta property="og:image" content="https://cambridgewi.com/wp-content/uploads/2016/06/make-cambridge-home-cambridge-wisconsin-chamber-of-commerce.jpg"><meta property="og:url" content="https://cambridgewi.com/make-cambridge-home/"><meta property="og:type" content="article"><link rel="stylesheet" href="https://cambridgewi.com/wp-content/plugins/oiopub-direct/images/style/output.css?260" type="text/css" />
+    <style id="x-generated-css">a,h1 a:hover,h2 a:hover,h3 a:hover,h4 a:hover,h5 a:hover,h6 a:hover,.x-breadcrumb-wrap a:hover,.widget ul li a:hover,.widget ol li a:hover,.widget.widget_text ul li a,.widget.widget_text ol li a,.widget_nav_menu .current-menu-item > a,.x-accordion-heading .x-accordion-toggle:hover,.x-comment-author a:hover,.x-comment-time:hover,.x-recent-posts a:hover .h-recent-posts{color:#347b92;}a:hover,.widget.widget_text ul li a:hover,.widget.widget_text ol li a:hover,.x-twitter-widget ul li a:hover{color:#1f716f;}.rev_slider_wrapper,a.x-img-thumbnail:hover,.x-slider-container.below,.page-template-template-blank-3-php .x-slider-container.above,.page-template-template-blank-6-php .x-slider-container.above{border-color:#347b92;}.entry-thumb:before,.x-pagination span.current,.flex-direction-nav a,.flex-control-nav a:hover,.flex-control-nav a.flex-active,.mejs-time-current,.x-dropcap,.x-skill-bar .bar,.x-pricing-column.featured h2,.h-comments-title small,.x-entry-share .x-share:hover,.x-highlight,.x-recent-posts .x-recent-posts-img:after{background-color:#347b92;}.x-nav-tabs > .active > a,.x-nav-tabs > .active > a:hover{box-shadow:inset 0 3px 0 0 #347b92;}.x-main{width:69.536945%;}.x-sidebar{width:25.536945%;}.x-comment-author,.x-comment-time,.comment-form-author label,.comment-form-email label,.comment-form-url label,.comment-form-rating label,.comment-form-comment label,.widget_calendar #wp-calendar caption,.widget.widget_rss li .rsswidget{font-family:"Roboto",sans-serif;font-weight:500;}.p-landmark-sub,.p-meta,input,button,select,textarea{font-family:"Varela",sans-serif;}.widget ul li a,.widget ol li a,.x-comment-time{color:hsl(0,0%,19%);}.widget_text ol li a,.widget_text ul li a{color:#347b92;}.widget_text ol li a:hover,.widget_text ul li a:hover{color:#1f716f;}.comment-form-author label,.comment-form-email label,.comment-form-url label,.comment-form-rating label,.comment-form-comment label,.widget_calendar #wp-calendar th,.p-landmark-sub strong,.widget_tag_cloud .tagcloud a:hover,.widget_tag_cloud .tagcloud a:active,.entry-footer a:hover,.entry-footer a:active,.x-breadcrumbs .current,.x-comment-author,.x-comment-author a{color:#1f716f;}.widget_calendar #wp-calendar th{border-color:#1f716f;}.h-feature-headline span i{background-color:#1f716f;}@media (max-width:979px){}html{font-size:14px;}@media (min-width:480px){html{font-size:14px;}}@media (min-width:767px){html{font-size:14px;}}@media (min-width:979px){html{font-size:14px;}}@media (min-width:1200px){html{font-size:14px;}}body{font-style:normal;font-weight:400;color:hsl(0,0%,19%);background-color:#f3f3f3;}.w-b{font-weight:400 !important;}h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6{font-family:"Roboto",sans-serif;font-style:normal;font-weight:500;}h1,.h1{letter-spacing:-0.035em;}h2,.h2{letter-spacing:-0.035em;}h3,.h3{letter-spacing:-0.035em;}h4,.h4{letter-spacing:-0.035em;}h5,.h5{letter-spacing:-0.035em;}h6,.h6{letter-spacing:-0.035em;}.w-h{font-weight:500 !important;}.x-container.width{width:88%;}.x-container.max{max-width:1200px;}.x-main.full{float:none;display:block;width:auto;}@media (max-width:979px){.x-main.full,.x-main.left,.x-main.right,.x-sidebar.left,.x-sidebar.right{float:none;display:block;width:auto !important;}}.entry-header,.entry-content{font-size:1rem;}body,input,button,select,textarea{font-family:"Varela",sans-serif;}h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6,h1 a,h2 a,h3 a,h4 a,h5 a,h6 a,.h1 a,.h2 a,.h3 a,.h4 a,.h5 a,.h6 a,blockquote{color:#1f716f;}.cfc-h-tx{color:#1f716f !important;}.cfc-h-bd{border-color:#1f716f !important;}.cfc-h-bg{background-color:#1f716f !important;}.cfc-b-tx{color:hsl(0,0%,19%) !important;}.cfc-b-bd{border-color:hsl(0,0%,19%) !important;}.cfc-b-bg{background-color:hsl(0,0%,19%) !important;}.x-btn,.button,[type="submit"]{color:#ffffff;border-color:#c8272a;background-color:#f97244;text-shadow:0 0.075em 0.075em rgba(0,0,0,0.5);border-radius:100em;}.x-btn:hover,.button:hover,[type="submit"]:hover{color:#ffffff;border-color:#f97244;background-color:#c8272a;text-shadow:0 0.075em 0.075em rgba(0,0,0,0.5);}.x-btn.x-btn-real,.x-btn.x-btn-real:hover{margin-bottom:0.25em;text-shadow:0 0.075em 0.075em rgba(0,0,0,0.65);}.x-btn.x-btn-real{box-shadow:0 0.25em 0 0 #a71000,0 4px 9px rgba(0,0,0,0.75);}.x-btn.x-btn-real:hover{box-shadow:0 0.25em 0 0 #a71000,0 4px 9px rgba(0,0,0,0.75);}.x-btn.x-btn-flat,.x-btn.x-btn-flat:hover{margin-bottom:0;text-shadow:0 0.075em 0.075em rgba(0,0,0,0.65);box-shadow:none;}.x-btn.x-btn-transparent,.x-btn.x-btn-transparent:hover{margin-bottom:0;border-width:3px;text-shadow:none;text-transform:uppercase;background-color:transparent;box-shadow:none;}.x-topbar .p-info a:hover,.x-widgetbar .widget ul li a:hover{color:#347b92;}.x-topbar .p-info,.x-topbar .p-info a,.x-navbar .desktop .x-nav > li > a,.x-navbar .desktop .sub-menu a,.x-navbar .mobile .x-nav li > a,.x-breadcrumb-wrap a,.x-breadcrumbs .delimiter{color:#347b92;}.x-navbar .desktop .x-nav > li > a:hover,.x-navbar .desktop .x-nav > .x-active > a,.x-navbar .desktop .x-nav > .current-menu-item > a,.x-navbar .desktop .sub-menu a:hover,.x-navbar .desktop .sub-menu .x-active > a,.x-navbar .desktop .sub-menu .current-menu-item > a,.x-navbar .desktop .x-nav .x-megamenu > .sub-menu > li > a,.x-navbar .mobile .x-nav li > a:hover,.x-navbar .mobile .x-nav .x-active > a,.x-navbar .mobile .x-nav .current-menu-item > a{color:#1f716f;}.x-navbar .desktop .x-nav > li > a:hover,.x-navbar .desktop .x-nav > .x-active > a,.x-navbar .desktop .x-nav > .current-menu-item > a{box-shadow:inset 0 4px 0 0 #347b92;}.x-navbar .desktop .x-nav > li > a{height:70px;padding-top:37px;}.x-navbar-fixed-top-active .x-navbar-wrap{margin-bottom:1px;}.x-navbar .desktop .x-nav > li ul{top:55px;;}@media (max-width:979px){.x-navbar-fixed-top-active .x-navbar-wrap{margin-bottom:0;}}body.x-navbar-fixed-top-active .x-navbar-wrap{height:70px;}.x-navbar-inner{min-height:70px;}.x-logobar-inner{padding-top:15px;padding-bottom:15px;}.x-brand{font-family:"Lato",sans-serif;font-size:42px;font-style:normal;font-weight:700;letter-spacing:-0.035em;color:#272727;}.x-brand:hover,.x-brand:focus{color:#272727;}.x-brand img{width:400px;}.x-navbar .x-nav-wrap .x-nav > li > a{font-family:"Raleway",sans-serif;font-style:normal;font-weight:400;letter-spacing:0.085em;text-transform:uppercase;}.x-navbar .desktop .x-nav > li > a{font-size:16px;}.x-navbar .desktop .x-nav > li > a:not(.x-btn-navbar-woocommerce){padding-left:10px;padding-right:10px;}.x-navbar .desktop .x-nav > li > a > span{margin-right:-0.085em;}.x-btn-navbar{margin-top:20px;}.x-btn-navbar,.x-btn-navbar.collapsed{font-size:24px;}@media (max-width:979px){body.x-navbar-fixed-top-active .x-navbar-wrap{height:auto;}.x-widgetbar{left:0;right:0;}}.entry-wrap{display:block;padding:60px;background-color:#fff;border-radius:40px;box-shadow:0 0.15em 0.35em 0 rgba(0,0,0,0.135);}.x-block-grid.four-up>li:nth-child(4n+1){clear:both;}.x-block-grid.four-up>li:nth-child(-n+4){margin-top:0;}.x-block-grid.four-up>li{width:21.25%;}.x-block-grid>li{display:block;float:left;height:auto;margin:5% 5% 0 0;padding:0;}@media (max-width:979px){.x-block-grid.four-up>li:nth-child(2n+1){clear:none;}.x-block-grid.four-up>li:nth-child(2n){margin-right:5%;}.x-block-grid.four-up>li:nth-child(4n){margin-right:0;}li.x-block-grid-item{margin-right:3% !important;}}@media (max-width:480px){.x-block-grid.four-up>li:nth-child(2n){margin-right:0;}li.x-block-grid-item p{font-size:11px;}}#cn-search-input{background:#FFF;border:1px solid #DFDFDF;border-right-width:0;-webkit-border-radius:3px 0 0 3px;border-radius:5px 0 0 5px;-moz-box-sizing:border-box;box-sizing:border-box;color:#888;display:inline-block;font-size:12px;float:none;height:35px;line-height:200px;margin:-4px 0 1px 1px!important;padding:3px 6px;text-align:left;vertical-align:bottom;width:75%;}input#cn-search-submit{background:url(https://cambridgewi.com/wp-content/plugins/connections/assets/images/icons/search.png)8px center no-repeat #FFF;border:1px solid #DFDFDF;border-left-width:0;-webkit-border-radius:0 3px 3px 0;border-radius:0 3px 3px 0;cursor:pointer;font-size:12px;float:none;height:35px;line-height:200px;margin:-4px 1px 1px 0!important;padding:3px;text-align:left;vertical-align:bottom;width:30px!important;}</style><link rel="stylesheet" href="//fonts.googleapis.com/css?family=Varela:400,400i,700,700i|Roboto:500|Lato:700|Raleway:400&#038;subset=latin,latin-ext" type="text/css" media="all" data-x-google-fonts /></head>
+
+<body class="page-template-default page page-id-198 x-integrity x-integrity-light x-full-width-layout-active x-content-sidebar-active x-post-meta-disabled x-navbar-fixed-top-active x-v6_1_6 cornerstone-v3_1_6">
+
+<div id="x-root" class="x-root">
+
+
+    <div id="top" class="site">
+
+
+
+        <header class="masthead masthead-stacked" role="banner">
+
+
+            <div class="x-topbar">
+                <div class="x-topbar-inner x-container max width">
+                    <div class="x-social-global"><a href="https://www.facebook.com/Cambridge-Chamber-of-Commerce-WI-107718109259411/?fref=ts" class="facebook" title="Facebook" target="_blank"><i class="x-icon-facebook-square" data-x-icon="&#xf082;" aria-hidden="true"></i></a><a href="http://www.instagram.com/visitcambridgewi/" class="instagram" title="Instagram" target="_blank"><i class="x-icon-instagram" data-x-icon="&#xf16d;" aria-hidden="true"></i></a><a href="http://www.pinterest.com/cambridgewi/" class="pinterest" title="Pinterest" target="_blank"><i class="x-icon-pinterest-square" data-x-icon="&#xf0d3;" aria-hidden="true"></i></a></div>    </div>
+            </div>
+
+
+
+            <div class="x-logobar">
+                <div class="x-logobar-inner">
+                    <div class="x-container max width">
+
+                        <h1 class="visually-hidden">Cambridge, Wisconsin Chamber Of Commerce</h1>
+                        <a href="https://cambridgewi.com/" class="x-brand img" title="Your Source For All Things Cambridge">
+                            <img src="//cambridgewi.com/wp-content/uploads/2016/06/cambridge-chamber-logo-800.jpg" alt="Your Source For All Things Cambridge"></a>      </div>
+                </div>
+            </div>
+
+            <div class="x-navbar-wrap">
+                <div class="x-navbar">
+                    <div class="x-navbar-inner">
+                        <div class="x-container max width">
+
+                            <a href="#" id="x-btn-navbar" class="x-btn-navbar collapsed" data-x-toggle="collapse-b" data-x-toggleable="x-nav-wrap-mobile" aria-selected="false" aria-expanded="false" aria-controls="x-widgetbar">
+                                <i class="x-icon-bars" data-x-icon="&#xf0c9;"></i>
+                                <span class="visually-hidden">Navigation</span>
+                            </a>
+
+                            <nav class="x-nav-wrap desktop" role="navigation">
+                                <ul id="menu-primary-menu" class="x-nav"><li id="menu-item-209" class="menu-item menu-item-type-custom menu-item-object-custom current-menu-ancestor current-menu-parent menu-item-has-children menu-item-209"><a href="#"><span>Do A Day Of Play</span></a>
+                                    <ul class="sub-menu">
+                                        <li id="menu-item-207" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-207"><a href="https://cambridgewi.com/active-play-lake-ripley-and-camrock-trails/"><span>Active Play, Lake Ripley And CamRock Trails</span></a></li>
+                                        <li id="menu-item-206" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-206"><a href="https://cambridgewi.com/artful-play/"><span>Artful Play</span></a></li>
+                                        <li id="menu-item-205" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-205"><a href="https://cambridgewi.com/family-playtime/"><span>Family Playtime</span></a></li>
+                                        <li id="menu-item-204" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-204"><a href="https://cambridgewi.com/romantic-play-and-weddings/"><span>Romantic Play And Weddings</span></a></li>
+                                        <li id="menu-item-351" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-351"><a href="https://cambridgewi.com/professional-services/"><span>Professional Services</span></a></li>
+                                        <li id="menu-item-208" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-208"><a href="https://cambridgewi.com/playing-with-our-past/"><span>Play With Our Past</span></a></li>
+                                        <li id="menu-item-202" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-202"><a href="https://cambridgewi.com/playful-shopping/"><span>Playful Shopping</span></a></li>
+                                        <li id="menu-item-235" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-235"><a href="https://cambridgewi.com/play-over-50-2/"><span>Play For Seniors</span></a></li>
+                                        <li id="menu-item-201" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-201"><a href="https://cambridgewi.com/stay-and-play/"><span>Stay And Play</span></a></li>
+                                        <li id="menu-item-203" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-203"><a href="https://cambridgewi.com/play-for-foodies/"><span>Foodie Play</span></a></li>
+                                        <li id="menu-item-352" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-352"><a href="https://cambridgewi.com/community-services/"><span>Community Services</span></a></li>
+                                        <li id="menu-item-200" class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-198 current_page_item menu-item-200"><a href="https://cambridgewi.com/make-cambridge-home/"><span>Make Cambridge Home</span></a></li>
+                                    </ul>
+                                </li>
+                                    <li id="menu-item-153" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-153"><a href="https://cambridgewi.com/events-calendar/"><span>Calendar Of Events</span></a></li>
+                                    <li id="menu-item-154" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-154"><a href="https://cambridgewi.com/store/"><span>Online Store</span></a>
+                                        <ul class="sub-menu">
+                                            <li id="menu-item-156" class="menu-item menu-item-type-ecwid_menu_item menu-item-object-ecwid-cart menu-item-156"><a href="https://cambridgewi.com/store/#!cart" data-ecwid-page="cart"><span>Shopping Cart</span></a></li>
+                                            <li id="menu-item-157" class="menu-item menu-item-type-ecwid_menu_item menu-item-object-ecwid-product-search menu-item-157"><a href="https://cambridgewi.com/store/#!search" data-ecwid-page="search"><span>Product Search</span></a></li>
+                                        </ul>
+                                    </li>
+                                    <li id="menu-item-598" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-598"><a href="https://cambridgewi.com/member-directory/"><span>Chamber Members</span></a>
+                                        <ul class="sub-menu">
+                                            <li id="menu-item-696" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-696"><a href="https://cambridgewi.com/member-directory/chamber-forms/"><span>Membership Information</span></a></li>
+                                        </ul>
+                                    </li>
+                                    <li id="menu-item-312" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-312"><a href="https://cambridgewi.com/cambridge-community-guide/"><span>Community Guide</span></a>
+                                        <ul class="sub-menu">
+                                            <li id="menu-item-556" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-556"><a href="https://cambridgewi.com/contact-us/"><span>Contact Us</span></a></li>
+                                        </ul>
+                                    </li>
+                                    <li id="menu-item-707" class="menu-item menu-item-type-post_type menu-item-object-post menu-item-707"><a href="https://cambridgewi.com/2016/10/discover-ways-to-play-in-cambridge/"><span>Video Cambridge- See what you&#8217;ll LOVE!</span></a></li>
+                                </ul></nav>
+
+                            <div id="x-nav-wrap-mobile" class="x-nav-wrap mobile x-collapsed" data-x-toggleable="x-nav-wrap-mobile" data-x-toggle-collapse="1" aria-hidden="true" aria-labelledby="x-btn-navbar">
+                                <ul id="menu-primary-menu-1" class="x-nav"><li class="menu-item menu-item-type-custom menu-item-object-custom current-menu-ancestor current-menu-parent menu-item-has-children menu-item-209"><a href="#"><span>Do A Day Of Play</span></a>
+                                    <ul class="sub-menu">
+                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-207"><a href="https://cambridgewi.com/active-play-lake-ripley-and-camrock-trails/"><span>Active Play, Lake Ripley And CamRock Trails</span></a></li>
+                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-206"><a href="https://cambridgewi.com/artful-play/"><span>Artful Play</span></a></li>
+                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-205"><a href="https://cambridgewi.com/family-playtime/"><span>Family Playtime</span></a></li>
+                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-204"><a href="https://cambridgewi.com/romantic-play-and-weddings/"><span>Romantic Play And Weddings</span></a></li>
+                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-351"><a href="https://cambridgewi.com/professional-services/"><span>Professional Services</span></a></li>
+                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-208"><a href="https://cambridgewi.com/playing-with-our-past/"><span>Play With Our Past</span></a></li>
+                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-202"><a href="https://cambridgewi.com/playful-shopping/"><span>Playful Shopping</span></a></li>
+                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-235"><a href="https://cambridgewi.com/play-over-50-2/"><span>Play For Seniors</span></a></li>
+                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-201"><a href="https://cambridgewi.com/stay-and-play/"><span>Stay And Play</span></a></li>
+                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-203"><a href="https://cambridgewi.com/play-for-foodies/"><span>Foodie Play</span></a></li>
+                                        <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-352"><a href="https://cambridgewi.com/community-services/"><span>Community Services</span></a></li>
+                                        <li class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-198 current_page_item menu-item-200"><a href="https://cambridgewi.com/make-cambridge-home/"><span>Make Cambridge Home</span></a></li>
+                                    </ul>
+                                </li>
+                                    <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-153"><a href="https://cambridgewi.com/events-calendar/"><span>Calendar Of Events</span></a></li>
+                                    <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-154"><a href="https://cambridgewi.com/store/"><span>Online Store</span></a>
+                                        <ul class="sub-menu">
+                                            <li class="menu-item menu-item-type-ecwid_menu_item menu-item-object-ecwid-cart menu-item-156"><a href="https://cambridgewi.com/store/#!cart" data-ecwid-page="cart"><span>Shopping Cart</span></a></li>
+                                            <li class="menu-item menu-item-type-ecwid_menu_item menu-item-object-ecwid-product-search menu-item-157"><a href="https://cambridgewi.com/store/#!search" data-ecwid-page="search"><span>Product Search</span></a></li>
+                                        </ul>
+                                    </li>
+                                    <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-598"><a href="https://cambridgewi.com/member-directory/"><span>Chamber Members</span></a>
+                                        <ul class="sub-menu">
+                                            <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-696"><a href="https://cambridgewi.com/member-directory/chamber-forms/"><span>Membership Information</span></a></li>
+                                        </ul>
+                                    </li>
+                                    <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-312"><a href="https://cambridgewi.com/cambridge-community-guide/"><span>Community Guide</span></a>
+                                        <ul class="sub-menu">
+                                            <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-556"><a href="https://cambridgewi.com/contact-us/"><span>Contact Us</span></a></li>
+                                        </ul>
+                                    </li>
+                                    <li class="menu-item menu-item-type-post_type menu-item-object-post menu-item-707"><a href="https://cambridgewi.com/2016/10/discover-ways-to-play-in-cambridge/"><span>Video Cambridge- See what you&#8217;ll LOVE!</span></a></li>
+                                </ul></div>
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="x-breadcrumb-wrap">
+                <div class="x-container max width">
+
+                    <div class="x-breadcrumbs"><a href="https://cambridgewi.com/" ><span class="home"><i class="x-icon-home" data-x-icon="&#xf015;"></i></span></a> <span class="delimiter"><i class="x-icon-angle-right" data-x-icon="&#xf105;"></i></span> <a href="https://cambridgewi.com/make-cambridge-home/" class="current" title="You Are Here" >Make Cambridge Home</a></div>
+
+                </div>
+            </div>
+
+        </header>
+
+
+
+        <div class="x-container max width offset">
+            <div class="x-main left" role="main">
+
+
+                <article id="post-198" class="post-198 page type-page status-publish has-post-thumbnail hentry">
+                    <div class="entry-featured">
+                        <div class="entry-thumb"><img width="862" height="400" src="https://cambridgewi.com/wp-content/uploads/2016/06/make-cambridge-home-cambridge-wisconsin-chamber-of-commerce-862x400.jpg" class="attachment-entry size-entry wp-post-image" alt="" /></div>  </div>
+                    <div class="entry-wrap">
+                        <header class="entry-header">
+                            <h1 class="entry-title">Make Cambridge Home</h1>
+                        </header>
+
+
+
+                        <div class="entry-content content">
+
+
+                            <p>We find that some visitors fall in love with our village and want to make Cambridge their home.  With top-ranked schools, sparkling Lake Ripley, a playful spirit and ideal location between Madison and Milwaukee, we’re not surprised.  Our knowledgeable area realtors, insurance professionals, and two local banks, <a href="http://www.ucbwi.com/" target="_blank">United Community Bank</a> and <a href="http://www.badgerbank.com" target="_blank">Badger Bank</a>, can help make Cambridge living a reality for you.  For senior living, discover Home Again, a new independent living and memory care facility for folks who wish to continue living in Cambridge during their senior years.  Wanting to build? Check out the budding development nestled near the vines of Cambridge Winery.  Visit <a href="http://www.cambridge.k12.wi.us" target="_blank">www.cambridge.k12.wi.us</a> for a video about our remodeled and top ranking schools.  We take special pride in our community strength with area clubs and organizations including The Cambridge Foundation, Cambridge Activities Program (CAP) and the Cambridge EMS and Volunteer Fire Department.  At www.cambridgewi.com you’ll find community businesspeople who are ready to be a welcoming resource for pet services, landscaping, remodeling, churches, groceries and everything else you’ll need to settle in to Cambridge living.</p>
+                            <ul  class="x-block-grid two-up" ><li  class="x-block-grid-item" ><a  class="x-img x-img-link x-img-none none"  href="http://www.cambridge.k12.wi.us/" title="Cambridge School District" target="_blank"   data-options="thumbnail: 'https://cambridgewi.com/wp-content/uploads/2016/06/nikolay-middle-school.jpg'"><img src="https://cambridgewi.com/wp-content/uploads/2016/06/nikolay-middle-school.jpg" alt="Cambridge School District"></a><a  class="x-btn x-btn-rounded x-btn-large x-btn-block"  href="http://www.cambridge.k12.wi.us/" title="Cambridge School District" target="_blank"   data-options="thumbnail: ''">Visit The Cambridge School District!</a></li><li  class="x-block-grid-item" ><a  class="x-img x-img-link x-img-none none"  href="http://www.ci.cambridge.wi.us/" title="Village Of Cambridge" target="_blank"   data-options="thumbnail: 'https://cambridgewi.com/wp-content/uploads/2016/06/village-of-cambridge.jpg'"><img src="https://cambridgewi.com/wp-content/uploads/2016/06/village-of-cambridge.jpg" alt="Village Of Cambridge Wisconsin"></a><a  class="x-btn x-btn-rounded x-btn-large x-btn-block"  href="http://www.ci.cambridge.wi.us/" title="Village Of Cambridge" target="_blank"   data-options="thumbnail: ''">Visit The Cambridge Municipal Website!</a></li></ul>
+                            <p>If you are looking for a specific organization, <strong>please use the search form below.</strong></p>
+                            <div id="cn-top" style="position: absolute; top: 0; right: 0;"></div><div class="cn-list" id="cn-list" data-connections-version="8.21-0.6"><div class="cn-template cn-cmap" id="cn-cmap" data-template-version="5.3"><div class="cn-list-head cn-clear" id="cn-list-head">
+
+                            <div id="cn-search-messages"><ul class="cn-search-message-list">
+                                <li class="cn-search-message-list-item" id="cn-search-message-list-item-cn-char">The results are being filtered by the character: V</li>
+                            </ul><div id="cn-clear-search"><a class="button btn" id="cn-clear-search-button" href="https://cambridgewi.com/make-cambridge-home/">Clear Search</a></div>
+                            </div>
+
+                            <form class="cn-form" id="cn-cat-select" action="/make-cambridge-home/" method="get"><span class="cn-search"><label for="cn-search-input">Search Directory</label><input type="text" id="cn-search-input" name="cn-s" value="" placeholder="Search"/><input type="submit" name="" id="cn-search-submit" class="cn-search-button" value="Search Directory" style="text-indent: -9999px;" tabindex="-1" /></span></form><div class="cn-alphaindex">
+                            <a class="cn-char" title="A" href="https://cambridgewi.com/make-cambridge-home/char/A/">A</a>
+                            <a class="cn-char" title="B" href="https://cambridgewi.com/make-cambridge-home/char/B/">B</a>
+                            <a class="cn-char" title="C" href="https://cambridgewi.com/make-cambridge-home/char/C/">C</a>
+                            <a class="cn-char" title="D" href="https://cambridgewi.com/make-cambridge-home/char/D/">D</a>
+                            <a class="cn-char" title="E" href="https://cambridgewi.com/make-cambridge-home/char/E/">E</a>
+                            <a class="cn-char" title="F" href="https://cambridgewi.com/make-cambridge-home/char/F/">F</a>
+                            <a class="cn-char" title="G" href="https://cambridgewi.com/make-cambridge-home/char/G/">G</a>
+                            <a class="cn-char" title="H" href="https://cambridgewi.com/make-cambridge-home/char/H/">H</a>
+                            <a class="cn-char" title="J" href="https://cambridgewi.com/make-cambridge-home/char/J/">J</a>
+                            <a class="cn-char" title="K" href="https://cambridgewi.com/make-cambridge-home/char/K/">K</a>
+                            <a class="cn-char" title="L" href="https://cambridgewi.com/make-cambridge-home/char/L/">L</a>
+                            <a class="cn-char" title="M" href="https://cambridgewi.com/make-cambridge-home/char/M/">M</a>
+                            <a class="cn-char" title="P" href="https://cambridgewi.com/make-cambridge-home/char/P/">P</a>
+                            <a class="cn-char" title="R" href="https://cambridgewi.com/make-cambridge-home/char/R/">R</a>
+                            <a class="cn-char" title="S" href="https://cambridgewi.com/make-cambridge-home/char/S/">S</a>
+                            <a class="cn-char" title="T" href="https://cambridgewi.com/make-cambridge-home/char/T/">T</a>
+                            <a class="cn-char" title="U" href="https://cambridgewi.com/make-cambridge-home/char/U/">U</a>
+                            <a class="cn-char-current" title="V" href="https://cambridgewi.com/make-cambridge-home/char/V/">V</a>
+                            <a class="cn-char" title="W" href="https://cambridgewi.com/make-cambridge-home/char/W/">W</a>
+                        </div>
+                        </div>
+                            <div class="connections-list cn-list-body cn-clear" id="cn-list-body">
+                                <div class="cn-list-section-head" id="cn-char-V"></div><div class="cn-list-row-alternate vcard organization chamber-members make-cambridge-home playful-shopping professional-services" id="dean-bluhm" data-entry-type="organization" data-entry-id="112" data-entry-slug="dean-bluhm"><div id="entry-id-1125b32ad8e1716e"  class="cn-entry cn-background-gradient cn-background-shadow"   style="background-color: #ffffff; border: 1px solid #487fb5; border-radius: 8px; margin: 8px 0; padding: 10px; position: relative">
+
+                                <div class="cn-left">
+
+                                    <span class="cn-image-style"><span style="display: block; max-width: 100%; width: 225px"><img width="225" height="150" sizes="100vw" class="cn-image logo" alt="Logo for Village Pharmacy" title="Logo for Village Pharmacy" srcset="//cambridgewi.com/wp-content/uploads/connections-images/dean-bluhm/VillagePharmacy-e04951b21968ae4d9fd04cb14ce08ade.jpg 1x"/></span></span>
+                                </div> <!-- /.cn-left -->
+
+                                <div class="cn-right">
+
+                                    <div style="margin-bottom: 5px;">
+
+                                        <h3><span class="org fn notranslate">Village Pharmacy</span>
+                                        </h3>
+                                        <span class="org"><span class="organization-name notranslate" style="display: none;">Village Pharmacy</span></span>
+                                        <span class="cn-contact-block"><span class="contact-given-name notranslate">Dean</span> <span class="contact-family-name notranslate">Bluhm</span></span>
+                                    </div>
+
+                                    <span class="address-block"><span class="adr cn-address"><span class="street-address notranslate">109 W. Main Street</span> <span class="locality">Cambridge</span>, <span class="region">Wi</span> <span class="postal-code">53523</span> <span class="type" style="display: none;">work</span></span><span class="adr cn-address"><span class="street-address notranslate">PO Box 69</span> <span class="locality">Cambridge</span>, <span class="region">Wi</span> <span class="postal-code">53523</span> <span class="type" style="display: none;">work</span></span></span>
+                                    <span class="phone-number-block">
+	<span class="tel cn-phone-number">Phone: <a class="value" href="tel:(608) 423-3231" value="6084233231">(608) 423-3231</a><span class="type" style="display: none;">work</span></span>
+
+</span>
+                                    <span class="email-address-block">
+	<span class="email cn-email-address">Email: <span class="email-address"><a class="value" title="Village Pharmacy" href="mailto:bluhmrph@yahoo.com">bluhmrph@yahoo.com</a></span><span class="type" style="display: none;">INTERNET</span></span>
+</span>
+                                </div><!-- /.cn-right -->
+
+                                <div class="cn-clear"></div>
+
+
+                                <div class="cn-clear" style="display:table;margin: 10px 0;width:100%;">
+                                    <div style="display:table-cell;vertical-align:middle;">
+                                    </div>
+                                    <div style="display:table-cell;text-align:right;vertical-align:middle;">
+                                    </div>
+                                </div>
+
+                                <div class="cn-tray-links">
+
+                                    <div class="cn-left">
+                                        <a class="cn-bio-anchor cn-cmap-toggle" id="bio-anchor-1125b32ad8e1716e" href="#" data-uuid="1125b32ad8e1716e" data-div-id="bio-block-1125b32ad8e1716e">Show Description</a>		</div> <!-- /.cn-left -->
+
+                                    <div class="cn-right">
+                                        <a class="cn-map-anchor cn-cmap-toggle" id="map-anchor-1125b32ad8e1716e" href="#" data-uuid="1125b32ad8e1716e" data-div-id="map-block-1125b32ad8e1716e">Show Map</a>
+                                    </div> <!-- /.cn-right -->
+                                </div> <!-- /.cn-tray-links -->
+
+                                <div class="cn-clear"></div>
+
+                                <div class="cn-content-tray">
+
+                                    <div class="cn-cmap-tab cn-bio-tray" id="bio-block-1125b32ad8e1716e" data-type="bio" style="display: none;">
+
+                                        <h4>Description</h4>
+                                        <div class="cn-biography"><p>Your local pharamacy right here in Cambridge features a drugstore and prescription service, as well as a whole array of interesting and adorable cards and gifts. Stop by and peruse our selection!</p>
+                                        </div>
+
+                                        <div class="cn-clear"></div>
+
+                                    </div>
+
+
+                                    <div class="cn-cmap-tab cn-gmap" id="map-block-1125b32ad8e1716e" data-type="map" style="display: none;"><div class="cn-gmap" id="map-1125b32ad8e1716e" data-address="109 W. Main Street, Cambridge, Wi, 53523" data-latitude="43.003396000000" data-longitude="-89.017151000000" style="height: 400px" data-maptype="ROADMAP" data-zoom="13"></div>
+                                    </div>	</div> <!-- /.cn-content-tray -->
+                            </div>
+
+                            </div>
+                            </div>
+                            <div class="cn-clear" id="cn-list-foot">
+
+                            </div>
+
+                        </div>
+
+                        </div>
+
+
+                        </div>
+
+                    </div>
+                </article>
+
+            </div>
+
+
+
+            <aside class="x-sidebar right" role="complementary">
+                <div id="rhcoming_events_widget-2" class="widget widget_rhcoming_events_widget"><h4 class="h-widget">Whats Happening In Cambridge</h4><div id="rhc-upcoming-0"></div><div id="uew_1" class="rhc_supe_holder rhc-side-1"  data-page="0" data-number="5" data-atts="{&quot;uid&quot;:1,&quot;test&quot;:&quot;&quot;,&quot;page&quot;:&quot;0&quot;,&quot;number&quot;:&quot;5&quot;,&quot;taxonomy&quot;:&quot;&quot;,&quot;terms&quot;:&quot;&quot;,&quot;terms_children&quot;:&quot;&quot;,&quot;template&quot;:&quot;widget_upcoming_events.php&quot;,&quot;class&quot;:&quot;rhc_supe_holder&quot;,&quot;prefix&quot;:&quot;uew&quot;,&quot;parse_postmeta&quot;:&quot;fc_click_link&quot;,&quot;parse_taxonomy&quot;:&quot;1&quot;,&quot;parse_taxonomymeta&quot;:&quot;1&quot;,&quot;order&quot;:&quot;ASC&quot;,&quot;date&quot;:&quot;&quot;,&quot;date_end&quot;:&quot;&quot;,&quot;date_compare&quot;:&quot;&quot;,&quot;date_end_compare&quot;:&quot;&quot;,&quot;horizon&quot;:&quot;day&quot;,&quot;allday&quot;:&quot;&quot;,&quot;no_events_message&quot;:&quot;&quot;,&quot;post_status&quot;:&quot;publish&quot;,&quot;post_type&quot;:&quot;events&quot;,&quot;author&quot;:&quot;&quot;,&quot;author_current&quot;:&quot;0&quot;,&quot;do_shortcode&quot;:&quot;1&quot;,&quot;the_content&quot;:&quot;0&quot;,&quot;separator&quot;:&quot;&quot;,&quot;holder&quot;:&quot;1&quot;,&quot;dayspast&quot;:&quot;1&quot;,&quot;premiere&quot;:&quot;0&quot;,&quot;auto&quot;:&quot;0&quot;,&quot;hideempty&quot;:&quot;0&quot;,&quot;feed&quot;:&quot;&quot;,&quot;words&quot;:&quot;10&quot;,&quot;render_images&quot;:&quot;&quot;,&quot;calendar_url&quot;:&quot;https:\/\/cambridgewi.com\/events-calendar\/&quot;,&quot;loading_overlay&quot;:&quot;0&quot;,&quot;for_sidebar&quot;:&quot;1&quot;,&quot;post_id&quot;:&quot;&quot;,&quot;current_post&quot;:&quot;&quot;,&quot;rdate&quot;:&quot;&quot;,&quot;js_init_script&quot;:&quot;&quot;,&quot;vc_js_init_script&quot;:&quot;&quot;,&quot;nav&quot;:&quot;&quot;,&quot;tax_and_filter&quot;:&quot;&quot;,&quot;header&quot;:&quot;&quot;,&quot;hierarchical_filter&quot;:&quot;0&quot;,&quot;terms_hide_empty&quot;:&quot;0&quot;,&quot;tax_filter_multiple&quot;:&quot;1&quot;,&quot;geo_radius&quot;:&quot;&quot;,&quot;geo_center&quot;:&quot;&quot;,&quot;local_tz&quot;:&quot;&quot;,&quot;tax_and_filtering&quot;:&quot;0&quot;,&quot;ajaxurl&quot;:&quot;https:\/\/cambridgewi.com\/?rhc_action=supe_get_events&quot;,&quot;taxonomy_default&quot;:&quot;&quot;,&quot;terms_default&quot;:&quot;&quot;}"><div class="supe-head"></div><div class="supe-body"><div class="supe-item-holder"><div class="rhc-widget-upcoming-item  featured-[FEATURED] featured-0 rhc_top_image-imgset-0 rhc_dbox_image-imgset-0 rhc_tooltip_image-imgset-1 rhc_month_image-imgset-0" itemscope="" itemtype="http://schema.org/Event" data-post_id="1347">
+                    <!--featured-->
+
+                    <!--featured-->
+                    <div class="rhc-widget-upcoming">
+                        <div class="rhc-widget-upcoming-title">
+                            <a class="rhc-event-link" href="https://cambridgewi.com/events-calendar/?event_rdate=20180626120000%2C20180626130000" itemprop="url"><span class="rhc-title-in-link" itemprop="name">Cambridge Senior Meals</span></a>
+                            <div class="rhc-widget-date-time [NODATETIME]"><span class="rhc-widget-date rhc_date fc-date-format" data-udate="1530039600" data-fc_date_format="MMM d, yyyy" data-wptz1="-7" data-wptz2="America/Phoenix">Jun 26, 2018</span>&nbsp;<span class="rhc-widget-time rhc_date fc-date-format" data-udate="1530039600" data-fc_date_format="h:mmtt" data-wptz1="-7" data-wptz2="America/Phoenix">12:00pm</span></div>
+
+                        </div>
+                        <div class="rhc-description" itemprop="description">Cambridge Senior meals available every Tuesday and Friday at Noon<a class="upcoming-excerpt-more" href="https://cambridgewi.com/events-calendar/">...</a></div>
+                    </div>
+                    <div class="rhc-clear"></div>
+                    <meta itemprop="startDate" content="2018-06-26T12:00:00-07:00"><meta itemprop="endDate" content="2018-06-26T13:00:00-07:00"><div itemprop="location" itemscope="itemscope" itemtype="http://schema.org/Place"><meta itemprop="name" content="Amundson Center"><meta itemprop="hasMap" content="http://maps.google.com/?q=200+Spring+Street%2C+Cambridge%2C+WI+53523"><div itemprop="address" itemscope="itemscope" itemtype="http://schema.org/PostalAddress"><meta itemprop="streetAddress" content="200 Spring Steet"><meta itemprop="addressLocality" content="Cambridge"><meta itemprop="addressRegion" content="WI"><meta itemprop="postalCode" content="53523"></div></div></div>
+
+                    <div class="rhc-widget-upcoming-item  featured-[FEATURED] featured-0 rhc_top_image-imgset-0 rhc_dbox_image-imgset-0 rhc_tooltip_image-imgset-1 rhc_month_image-imgset-0" itemscope="" itemtype="http://schema.org/Event" data-post_id="1347">
+                        <!--featured-->
+
+                        <!--featured-->
+                        <div class="rhc-widget-upcoming">
+                            <div class="rhc-widget-upcoming-title">
+                                <a class="rhc-event-link" href="https://cambridgewi.com/events-calendar/?event_rdate=20180629120000%2C20180629130000" itemprop="url"><span class="rhc-title-in-link" itemprop="name">Cambridge Senior Meals</span></a>
+                                <div class="rhc-widget-date-time [NODATETIME]"><span class="rhc-widget-date rhc_date fc-date-format" data-udate="1530298800" data-fc_date_format="MMM d, yyyy" data-wptz1="-7" data-wptz2="America/Phoenix">Jun 29, 2018</span>&nbsp;<span class="rhc-widget-time rhc_date fc-date-format" data-udate="1530298800" data-fc_date_format="h:mmtt" data-wptz1="-7" data-wptz2="America/Phoenix">12:00pm</span></div>
+
+                            </div>
+                            <div class="rhc-description" itemprop="description">Cambridge Senior meals available every Tuesday and Friday at Noon<a class="upcoming-excerpt-more" href="https://cambridgewi.com/events-calendar/">...</a></div>
+                        </div>
+                        <div class="rhc-clear"></div>
+                        <meta itemprop="startDate" content="2018-06-29T12:00:00-07:00"><meta itemprop="endDate" content="2018-06-29T13:00:00-07:00"><div itemprop="location" itemscope="itemscope" itemtype="http://schema.org/Place"><meta itemprop="name" content="Amundson Center"><meta itemprop="hasMap" content="http://maps.google.com/?q=200+Spring+Street%2C+Cambridge%2C+WI+53523"><div itemprop="address" itemscope="itemscope" itemtype="http://schema.org/PostalAddress"><meta itemprop="streetAddress" content="200 Spring Steet"><meta itemprop="addressLocality" content="Cambridge"><meta itemprop="addressRegion" content="WI"><meta itemprop="postalCode" content="53523"></div></div></div>
+
+                    <div class="rhc-widget-upcoming-item  featured-[FEATURED] featured-0 rhc_top_image-imgset-0 rhc_dbox_image-imgset-0 rhc_tooltip_image-imgset-1 rhc_month_image-imgset-0" itemscope="" itemtype="http://schema.org/Event" data-post_id="1347">
+                        <!--featured-->
+
+                        <!--featured-->
+                        <div class="rhc-widget-upcoming">
+                            <div class="rhc-widget-upcoming-title">
+                                <a class="rhc-event-link" href="https://cambridgewi.com/events-calendar/?event_rdate=20180703120000%2C20180703130000" itemprop="url"><span class="rhc-title-in-link" itemprop="name">Cambridge Senior Meals</span></a>
+                                <div class="rhc-widget-date-time [NODATETIME]"><span class="rhc-widget-date rhc_date fc-date-format" data-udate="1530644400" data-fc_date_format="MMM d, yyyy" data-wptz1="-7" data-wptz2="America/Phoenix">Jul 3, 2018</span>&nbsp;<span class="rhc-widget-time rhc_date fc-date-format" data-udate="1530644400" data-fc_date_format="h:mmtt" data-wptz1="-7" data-wptz2="America/Phoenix">12:00pm</span></div>
+
+                            </div>
+                            <div class="rhc-description" itemprop="description">Cambridge Senior meals available every Tuesday and Friday at Noon<a class="upcoming-excerpt-more" href="https://cambridgewi.com/events-calendar/">...</a></div>
+                        </div>
+                        <div class="rhc-clear"></div>
+                        <meta itemprop="startDate" content="2018-07-03T12:00:00-07:00"><meta itemprop="endDate" content="2018-07-03T13:00:00-07:00"><div itemprop="location" itemscope="itemscope" itemtype="http://schema.org/Place"><meta itemprop="name" content="Amundson Center"><meta itemprop="hasMap" content="http://maps.google.com/?q=200+Spring+Street%2C+Cambridge%2C+WI+53523"><div itemprop="address" itemscope="itemscope" itemtype="http://schema.org/PostalAddress"><meta itemprop="streetAddress" content="200 Spring Steet"><meta itemprop="addressLocality" content="Cambridge"><meta itemprop="addressRegion" content="WI"><meta itemprop="postalCode" content="53523"></div></div></div>
+
+                    <div class="rhc-widget-upcoming-item  featured-[FEATURED] featured-0 rhc_top_image-imgset-0 rhc_dbox_image-imgset-0 rhc_tooltip_image-imgset-1 rhc_month_image-imgset-0" itemscope="" itemtype="http://schema.org/Event" data-post_id="1347">
+                        <!--featured-->
+
+                        <!--featured-->
+                        <div class="rhc-widget-upcoming">
+                            <div class="rhc-widget-upcoming-title">
+                                <a class="rhc-event-link" href="https://cambridgewi.com/events-calendar/?event_rdate=20180706120000%2C20180706130000" itemprop="url"><span class="rhc-title-in-link" itemprop="name">Cambridge Senior Meals</span></a>
+                                <div class="rhc-widget-date-time [NODATETIME]"><span class="rhc-widget-date rhc_date fc-date-format" data-udate="1530903600" data-fc_date_format="MMM d, yyyy" data-wptz1="-7" data-wptz2="America/Phoenix">Jul 6, 2018</span>&nbsp;<span class="rhc-widget-time rhc_date fc-date-format" data-udate="1530903600" data-fc_date_format="h:mmtt" data-wptz1="-7" data-wptz2="America/Phoenix">12:00pm</span></div>
+
+                            </div>
+                            <div class="rhc-description" itemprop="description">Cambridge Senior meals available every Tuesday and Friday at Noon<a class="upcoming-excerpt-more" href="https://cambridgewi.com/events-calendar/">...</a></div>
+                        </div>
+                        <div class="rhc-clear"></div>
+                        <meta itemprop="startDate" content="2018-07-06T12:00:00-07:00"><meta itemprop="endDate" content="2018-07-06T13:00:00-07:00"><div itemprop="location" itemscope="itemscope" itemtype="http://schema.org/Place"><meta itemprop="name" content="Amundson Center"><meta itemprop="hasMap" content="http://maps.google.com/?q=200+Spring+Street%2C+Cambridge%2C+WI+53523"><div itemprop="address" itemscope="itemscope" itemtype="http://schema.org/PostalAddress"><meta itemprop="streetAddress" content="200 Spring Steet"><meta itemprop="addressLocality" content="Cambridge"><meta itemprop="addressRegion" content="WI"><meta itemprop="postalCode" content="53523"></div></div></div>
+
+                    <div class="rhc-widget-upcoming-item  featured-[FEATURED] featured-0 rhc_top_image-imgset-0 rhc_dbox_image-imgset-0 rhc_tooltip_image-imgset-1 rhc_month_image-imgset-0" itemscope="" itemtype="http://schema.org/Event" data-post_id="1347">
+                        <!--featured-->
+
+                        <!--featured-->
+                        <div class="rhc-widget-upcoming">
+                            <div class="rhc-widget-upcoming-title">
+                                <a class="rhc-event-link" href="https://cambridgewi.com/events-calendar/?event_rdate=20180710120000%2C20180710130000" itemprop="url"><span class="rhc-title-in-link" itemprop="name">Cambridge Senior Meals</span></a>
+                                <div class="rhc-widget-date-time [NODATETIME]"><span class="rhc-widget-date rhc_date fc-date-format" data-udate="1531249200" data-fc_date_format="MMM d, yyyy" data-wptz1="-7" data-wptz2="America/Phoenix">Jul 10, 2018</span>&nbsp;<span class="rhc-widget-time rhc_date fc-date-format" data-udate="1531249200" data-fc_date_format="h:mmtt" data-wptz1="-7" data-wptz2="America/Phoenix">12:00pm</span></div>
+
+                            </div>
+                            <div class="rhc-description" itemprop="description">Cambridge Senior meals available every Tuesday and Friday at Noon<a class="upcoming-excerpt-more" href="https://cambridgewi.com/events-calendar/">...</a></div>
+                        </div>
+                        <div class="rhc-clear"></div>
+                        <meta itemprop="startDate" content="2018-07-10T12:00:00-07:00"><meta itemprop="endDate" content="2018-07-10T13:00:00-07:00"><div itemprop="location" itemscope="itemscope" itemtype="http://schema.org/Place"><meta itemprop="name" content="Amundson Center"><meta itemprop="hasMap" content="http://maps.google.com/?q=200+Spring+Street%2C+Cambridge%2C+WI+53523"><div itemprop="address" itemscope="itemscope" itemtype="http://schema.org/PostalAddress"><meta itemprop="streetAddress" content="200 Spring Steet"><meta itemprop="addressLocality" content="Cambridge"><meta itemprop="addressRegion" content="WI"><meta itemprop="postalCode" content="53523"></div></div></div>
+
+                    <script class="rhc-supe-last" data-last_date_start="2018-07-10T12:00:00" data-last_date_end="2018-07-10T13:00:00"></script></div></div><div class="rhc-clear"></div><div class="supe-footer"></div></div><!-- fullcalendar integrated uew --></div><div id="search-5" class="widget widget_search"><h4 class="h-widget">I Am Searching For&#8230;.</h4>
+                <form method="get" id="searchform" class="form-search" action="https://cambridgewi.com/">
+                    <label for="s" class="visually-hidden">Search</label>
+                    <input type="text" id="s" class="search-query" name="s" placeholder="Search" />
+                </form></div>      </aside>
+
+
+        </div>
+
+
+
+
+
+
+        <footer class="x-colophon bottom" role="contentinfo">
+            <div class="x-container max width">
+
+
+                <ul id="menu-footer-menu" class="x-nav"><li id="menu-item-335" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-335"><a href="https://cambridgewi.com/contact-us/">Contact Us</a></li>
+                    <li id="menu-item-162" class="menu-item menu-item-type-ecwid_menu_item menu-item-object-ecwid-store menu-item-162"><a href="https://cambridgewi.com/store/" data-ecwid-page="/">Store</a></li>
+                    <li id="menu-item-313" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-313"><a target="_blank" href="https://goo.gl/maps/TokosHFubno">Map Of Cambridge</a></li>
+                    <li id="menu-item-554" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-554"><a href="https://cambridgewi.com/wp-admin">Login</a></li>
+                </ul>
+                <div class="x-social-global"><a href="https://www.facebook.com/Cambridge-Chamber-of-Commerce-WI-107718109259411/?fref=ts" class="facebook" title="Facebook" target="_blank"><i class="x-icon-facebook-square" data-x-icon="&#xf082;" aria-hidden="true"></i></a><a href="http://www.instagram.com/visitcambridgewi/" class="instagram" title="Instagram" target="_blank"><i class="x-icon-instagram" data-x-icon="&#xf16d;" aria-hidden="true"></i></a><a href="http://www.pinterest.com/cambridgewi/" class="pinterest" title="Pinterest" target="_blank"><i class="x-icon-pinterest-square" data-x-icon="&#xf0d3;" aria-hidden="true"></i></a></div>
+                <div class="x-colophon-content">
+                    <p style="letter-spacing: 2px; text-transform: uppercase; opacity: 0.5; filter: alpha(opacity=60);">© 2016. <strong>Cambridge Chamber Of Commerce</strong><br />
+                        102 W. Main Street, P.O. Box 572<br />
+                        CAMBRIDGE, WI 53523<br />
+                        P: <a href="tel:608-423-3780">(608) 423-3780</a> • E: <a href="mailto:office@cambridgewi.com">office@cambridgewi.com</a>
+                    </p>          </div>
+
+            </div>
+        </footer>
+
+
+
+
+    </div> <!-- END .x-site -->
+
+
+    <a class="x-scroll-top right fade" title="Back to Top">
+        <i class="x-icon-angle-up" data-x-icon="&#xf106;"></i>
+    </a>
+
+    <script>
+
+      jQuery(document).ready(function($) {
+
+        var windowObj            = $(window);
+        var body                 = $('body');
+        var bodyOffsetBottom     = windowObj.scrollBottom();             // 1
+        var bodyHeightAdjustment = body.height() - bodyOffsetBottom;     // 2
+        var bodyHeightAdjusted   = body.height() - bodyHeightAdjustment; // 3
+        var scrollTopAnchor      = $('.x-scroll-top');
+
+        function sizingUpdate(){
+          var bodyOffsetTop = windowObj.scrollTop();
+          if ( bodyOffsetTop > ( bodyHeightAdjusted * 0.75 ) ) {
+            scrollTopAnchor.addClass('in');
+          } else {
+            scrollTopAnchor.removeClass('in');
+          }
+        }
+
+        windowObj.bind('scroll', sizingUpdate).resize(sizingUpdate);
+        sizingUpdate();
+
+        scrollTopAnchor.click(function(){
+          $('html, body').animate({ scrollTop: 0 }, 850, 'xEaseInOutExpo');
+          return false;
+        });
+
+      });
+
+      </script>
+
+
+</div> <!-- END .x-root -->
+
+<script type='text/javascript' src='//cambridgewi.com/wp-content/plugins/connections/vendor/picturefill/picturefill.min.js?ver=2.3.1'></script>
+<script type='text/javascript' src='https://cambridgewi.com/wp-content/plugins/cornerstone/assets/dist/js/site/cs-body.js?ver=3.1.6'></script>
+<script type='text/javascript' src='https://cambridgewi.com/wp-content/themes/x/framework/dist/js/site/x.js?ver=6.1.6'></script>
+<script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/comment-reply.min.js?ver=4.9.6'></script>
+<script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/jquery/jquery.ui.touch-punch.js?ver=0.2.2'></script>
+<script type='text/javascript' src='https://cambridgewi.com/wp-includes/js/wp-embed.min.js?ver=4.9.6'></script>
+<script type='text/javascript' src='//cambridgewi.com/wp-content/plugins/connections/vendor/chosen/chosen.jquery.min.js?ver=1.7'></script>
+<script type='text/javascript' src='https://maps.googleapis.com/maps/api/js?libraries=geometry&#038;ver=8.21'></script>
+<script type='text/javascript' src='//cambridgewi.com/wp-content/plugins/connections/vendor/jquery-gomap/jquery.gomap.min.js?ver=1.3.3'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var CNT_cMap = {"show":{"bio":"Show Description","map":"Show Map","notes":"Show Notes"},"hide":{"bio":"Close Description","map":"Close Map","notes":"Close Notes"}};
+/* ]]> */
+</script>
+<script type='text/javascript' src='//cambridgewi.com/wp-content/plugins/connections-cmap/cmap.min.js?ver=5.3'></script>
+<script id="x-custom-js">jQuery(function() {
+  jQuery(function($){ $('.x-search-shortcode #s').attr('placeholder','Enter Activities, Businesses, Entertainment, Whatever!'); });
+});
+
+<div id="fb-root"></div>
+<script>(function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) return;
+  js = d.createElement(s); js.id = id;
+  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.6";
+  fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));</script></script><script>jQuery(function($){$.backstretch(["https://cambridgewi.com/wp-content/uploads/2016/06/make-cambridge-home-background.jpg"], {"fade":"750","duration":"7500"} ); });</script>
+</body>
+</html>


### PR DESCRIPTION
This PR:
1. fixes the NullPointerExceptions that have occurred in HCardExtractor
2. supports the 'srcset' attribute in obtaining urls from img elements
3. fixes the fallback url extraction method to align with the spec by only obtaining url text from 'value'-class elements, or, if none defined, from non-'type'-class elements.

mvn clean test -> all tests pass