### PR TITLE
ANY23-353 fallback on string datatype for langstring with no lang

### DIFF
--- a/core/src/main/java/org/apache/any23/rdf/Any23ValueFactoryWrapper.java
+++ b/core/src/main/java/org/apache/any23/rdf/Any23ValueFactoryWrapper.java
@@ -22,6 +22,7 @@ import java.math.BigInteger;
 import java.util.Date;
 
 import org.apache.any23.extractor.IssueReport;
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
@@ -29,6 +30,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -164,6 +166,8 @@ public class Any23ValueFactoryWrapper implements ValueFactory {
 
     @Override
     public Literal createLiteral(String label, String language) {
+        if (StringUtils.isBlank(language))
+            return createLiteral(label);
         if (label == null)
             return null;
         return wrappedFactory.createLiteral(label, language);
@@ -171,6 +175,8 @@ public class Any23ValueFactoryWrapper implements ValueFactory {
 
     @Override
     public Literal createLiteral(String pref, IRI value) {
+        if (RDF.LANGSTRING.equals(value))
+            return createLiteral(pref);
         if (pref == null)
             return null;
         return wrappedFactory.createLiteral(pref, value);

--- a/core/src/test/java/org/apache/any23/Any23Test.java
+++ b/core/src/test/java/org/apache/any23/Any23Test.java
@@ -239,6 +239,8 @@ public class Any23Test extends Any23OnlineTestBase {
          */
         logger.debug("n3: " + n3);
         Assert.assertTrue(n3.length() > 0);
+
+        Assert.assertTrue(n3.contains("<http://dbpedia.org/resource/Trento> <http://dbpedia.org/property/mayor> \"Alessandro Andreatta\" ."));
     }
 
     /**


### PR DESCRIPTION
For string literals of datatype "langString" with no language tag, I'm simply falling back to type "string" (or using the default language if specified).

mvn clean test -> all tests pass

@lewismc any comments?