### PR TITLE
ANY23-355: Deprecate RDFa11Parser since Rio implementations are used instead

### DIFF
--- a/core/src/main/java/org/apache/any23/extractor/rdfa/RDFa11Parser.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/RDFa11Parser.java
@@ -49,8 +49,10 @@ import org.w3c.dom.NodeList;
  * @deprecated since 2.3 the {@link org.eclipse.rdf4j.rio.Rio} implementations 
  * are used to parse RDFa. Look at {@link org.apache.any23.extractor.rdf.RDFParserFactory#getRDFa10Parser}
  * and {@link org.apache.any23.extractor.rdf.RDFParserFactory#getRDFa11Parser}.
+ * 
  * @author Michele Mostarda (mostarda@fbk.eu)
  */
+@Deprecated
 public class RDFa11Parser {
 
     private static final Logger logger = LoggerFactory.getLogger(RDFa11Parser.class);

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/RDFa11Parser.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/RDFa11Parser.java
@@ -17,23 +17,6 @@
 
 package org.apache.any23.extractor.rdfa;
 
-import org.apache.any23.extractor.IssueReport;
-import org.apache.any23.extractor.ExtractionResult;
-import org.apache.any23.extractor.html.DomUtils;
-import org.apache.any23.rdf.RDFUtils;
-import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import javax.xml.transform.TransformerException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -43,11 +26,29 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
+import javax.xml.transform.TransformerException;
+import org.apache.any23.extractor.ExtractionResult;
+import org.apache.any23.extractor.IssueReport;
+import org.apache.any23.extractor.html.DomUtils;
+import org.apache.any23.rdf.RDFUtils;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * This parser is able to extract <a href="http://www.w3.org/TR/rdfa-syntax/">RDFa 1.0</a> and
  * <a href="http://www.w3.org/TR/rdfa-core/">RDFa 1.1</a> statements from any <i>(X)HTML</i> document.
- *
+ * @deprecated since 2.3 the {@link org.eclipse.rdf4j.rio.Rio} implementations 
+ * are used to parse RDFa. Look at {@link org.apache.any23.extractor.rdf.RDFParserFactory#getRDFa10Parser}
+ * and {@link org.apache.any23.extractor.rdf.RDFParserFactory#getRDFa11Parser}.
  * @author Michele Mostarda (mostarda@fbk.eu)
  */
 public class RDFa11Parser {

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/RDFa11ParserException.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/RDFa11ParserException.java
@@ -20,8 +20,12 @@ package org.apache.any23.extractor.rdfa;
 /**
  * Exception class raised by {@link RDFa11Parser}.
  *
+ * @deprecated since 2.3 the {@link org.eclipse.rdf4j.rio.Rio} implementations 
+ * are used to parse RDFa.
+ * 
  * @author Michele Mostarda (mostarda@fbk.eu)
  */
+@Deprecated
 public class RDFa11ParserException extends Exception {
 
     public RDFa11ParserException(String message) {


### PR DESCRIPTION
The [RDFParserFactory](https://github.com/apache/any23/blob/master/core/src/main/java/org/apache/any23/extractor/rdf/RDFParserFactory.java) uses Rio implementations, and as a consequence of this, the [RDFa11Parser](https://github.com/apache/any23/blob/master/core/src/main/java/org/apache/any23/extractor/rdfa/RDFa11Parser.java) is not longer used. Thus, it needs to be deprecated.