### PR TITLE
resolved mockito deprecation warnings

### DIFF
--- a/plugins/html-scraper/src/test/java/org/apache/any23/plugin/htmlscraper/HTMLScraperExtractorTest.java
+++ b/plugins/html-scraper/src/test/java/org/apache/any23/plugin/htmlscraper/HTMLScraperExtractorTest.java
@@ -25,9 +25,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 import java.io.IOException;
@@ -35,7 +33,8 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -61,7 +60,7 @@ public class HTMLScraperExtractorTest {
     @Test
     public void testGetExtractors() {
         final String[] extractors = extractor.getTextExtractors();
-        Assert.assertEquals( new HashSet<String>(Arrays.asList(extractors)).size(), 4 );
+        Assert.assertEquals( new HashSet<>(Arrays.asList(extractors)).size(), 4 );
     }
 
     @Test
@@ -76,17 +75,13 @@ public class HTMLScraperExtractorTest {
         extractor.run(ExtractionParameters.newDefault(), extractionContext, is, extractionResult);
 
         verify(extractionResult).writeTriple(
-                eq(pageIRI), eq(HTMLScraperExtractor.PAGE_CONTENT_DE_PROPERTY) , (Value) Matchers.anyObject())
-        ;
+                eq(pageIRI), eq(HTMLScraperExtractor.PAGE_CONTENT_DE_PROPERTY), any());
         verify(extractionResult).writeTriple(
-                eq(pageIRI), eq(HTMLScraperExtractor.PAGE_CONTENT_AE_PROPERTY) , (Value) Matchers.anyObject())
-        ;
+                eq(pageIRI), eq(HTMLScraperExtractor.PAGE_CONTENT_AE_PROPERTY), any());
         verify(extractionResult).writeTriple(
-                eq(pageIRI), eq(HTMLScraperExtractor.PAGE_CONTENT_LCE_PROPERTY) , (Value) Matchers.anyObject())
-        ;
+                eq(pageIRI), eq(HTMLScraperExtractor.PAGE_CONTENT_LCE_PROPERTY), any());
         verify(extractionResult).writeTriple(
-                eq(pageIRI), eq(HTMLScraperExtractor.PAGE_CONTENT_CE_PROPERTY) , (Value) Matchers.anyObject())
-        ;
+                eq(pageIRI), eq(HTMLScraperExtractor.PAGE_CONTENT_CE_PROPERTY), any());
     }
 
 }

--- a/plugins/office-scraper/src/test/java/org/apache/any23/plugin/officescraper/ExcelExtractorTest.java
+++ b/plugins/office-scraper/src/test/java/org/apache/any23/plugin/officescraper/ExcelExtractorTest.java
@@ -33,9 +33,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,22 +108,22 @@ public class ExcelExtractorTest {
     private void verifyPredicateOccurrence(TripleHandler mock, IRI predicate, int occurrence)
     throws TripleHandlerException {
         Mockito.verify( mock, Mockito.times(occurrence)).receiveTriple(
-                Mockito.<Resource>anyObject(),
+                Mockito.any(),
                 Mockito.eq(predicate),
-                Mockito.<Value>anyObject(),
-                Mockito.<IRI>any(),
-                Mockito.<ExtractionContext>anyObject()
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()
         );
     }
 
     private void verifyTypeOccurrence(TripleHandler mock, IRI type, int occurrence)
     throws TripleHandlerException {
         Mockito.verify( mock, Mockito.times(occurrence)).receiveTriple(
-                Mockito.<Resource>anyObject(),
+                Mockito.any(),
                 Mockito.eq(RDF.TYPE),
                 Mockito.eq(type),
-                Mockito.<IRI>any(),
-                Mockito.<ExtractionContext>anyObject()
+                Mockito.any(),
+                Mockito.any()
         );
     }
 


### PR DESCRIPTION
1. Changed `anyObject()` method to its alias `any()`
2. Removed usages of `Matchers` class

mvn clean test -> all tests passed