### PR TITLE
ANY23-362 resolved rdf4j deprecation warnings

### DIFF
--- a/core/src/main/java/org/apache/any23/extractor/rdf/BaseRDFExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/BaseRDFExtractor.java
@@ -27,8 +27,6 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RioSetting;
-import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Comment;
 import org.jsoup.nodes.DataNode;
@@ -48,7 +46,6 @@ import java.io.InputStream;
 import java.io.PushbackInputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
 import java.util.Iterator;
 
 /**
@@ -111,18 +108,6 @@ public abstract class BaseRDFExtractor implements Extractor.ContentExtractor {
     ) throws IOException, ExtractionException {
         try {
             final RDFParser parser = getParser(extractionContext, extractionResult);
-            parser.getParserConfig().setNonFatalErrors(new HashSet<RioSetting<?>>());
-
-            // Disable verification to ensure that DBPedia is accessible, given it uses so many custom datatypes
-            parser.getParserConfig().set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, true);
-            parser.getParserConfig().addNonFatalError(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES);
-            parser.getParserConfig().set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
-            parser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_DATATYPE_VALUES);
-            parser.getParserConfig().set(BasicParserSettings.NORMALIZE_DATATYPE_VALUES, false);
-            parser.getParserConfig().addNonFatalError(BasicParserSettings.NORMALIZE_DATATYPE_VALUES);
-            parser.getParserConfig().set(BasicParserSettings.VERIFY_RELATIVE_URIS, true);
-            parser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_RELATIVE_URIS);
-
 
             RDFFormat format = parser.getRDFFormat();
             String iri = extractionContext.getDocumentIRI().stringValue();

--- a/core/src/main/java/org/apache/any23/extractor/rdf/RDFXMLExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/RDFXMLExtractor.java
@@ -45,7 +45,7 @@ public class RDFXMLExtractor extends BaseRDFExtractor {
      * Default constructor, with no verification of data types and not stop at first error.
      */
     public RDFXMLExtractor() {
-        this(true, true);
+        this(false, false);
     }
 
     @Override

--- a/core/src/main/java/org/apache/any23/extractor/rdf/TriXExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/TriXExtractor.java
@@ -46,7 +46,7 @@ public class TriXExtractor extends BaseRDFExtractor {
      * Default constructor, with no verification of data types and not stop at first error.
      */
     public TriXExtractor() {
-        this(true, true);
+        this(false, false);
     }
 
     @Override

--- a/core/src/main/java/org/apache/any23/rdf/RDFUtils.java
+++ b/core/src/main/java/org/apache/any23/rdf/RDFUtils.java
@@ -69,6 +69,8 @@ public class RDFUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(RDFUtils.class);
 
+    private static final Statement[] EMPTY_STATEMENTS = new Statement[0];
+
     private RDFUtils() {}
 
     /**
@@ -443,7 +445,7 @@ public class RDFUtils {
      * @throws IllegalArgumentException if no extension matches.
      */
     public static Optional<RDFFormat> getFormatByExtension(String ext) {
-        if( ! ext.startsWith(".") )
+        if (!ext.startsWith("."))
             ext = "." + ext;
         return Rio.getParserFormatForFileName(ext);
     }
@@ -463,11 +465,10 @@ public class RDFUtils {
         final StatementCollector handler = new StatementCollector();
         final RDFParser parser = getParser(format);
         parser.getParserConfig().set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
-        parser.setStopAtFirstError(true);
         parser.setPreserveBNodeIDs(true);
         parser.setRDFHandler(handler);
         parser.parse(is, baseIRI);
-        return handler.getStatements().toArray( new Statement[handler.getStatements().size()] );
+        return handler.getStatements().toArray(EMPTY_STATEMENTS);
     }
 
     /**
@@ -508,11 +509,11 @@ public class RDFUtils {
      */
     public static Statement[] parseRDF(String resource) throws IOException {
         final int extIndex = resource.lastIndexOf('.');
-        if(extIndex == -1)
+        if (extIndex == -1)
             throw new IllegalArgumentException("Error while detecting the extension in resource name " + resource);
         final String extension = resource.substring(extIndex + 1);
-        return parseRDF( getFormatByExtension(extension).orElseThrow(Rio.unsupportedFormat(extension))
-        		        , RDFUtils.class.getResourceAsStream(resource) );
+        return parseRDF(getFormatByExtension(extension).orElseThrow(Rio.unsupportedFormat(extension)),
+                RDFUtils.class.getResourceAsStream(resource));
     }
 
     /**

--- a/mime/src/main/java/org/apache/any23/mime/TikaMIMETypeDetector.java
+++ b/mime/src/main/java/org/apache/any23/mime/TikaMIMETypeDetector.java
@@ -29,6 +29,7 @@ import org.apache.tika.mime.MimeTypes;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -110,9 +111,7 @@ public class TikaMIMETypeDetector implements MIMETypeDetector {
     public static boolean checkTurtleFormat(InputStream is) throws IOException {
         String sample = extractDataSample(is, '.');
         RDFParser turtleParser = Rio.createParser(RDFFormat.TURTLE);
-        turtleParser.setDatatypeHandling(RDFParser.DatatypeHandling.VERIFY);
-        turtleParser.setStopAtFirstError(true);
-        turtleParser.setVerifyData(true);
+        turtleParser.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
         ByteArrayInputStream bais = new ByteArrayInputStream(sample.getBytes());
         try {
             turtleParser.parse(bais, "");


### PR DESCRIPTION
1. resolved rdf4j deprecation warnings
2. refactored for code style and improved singleton pattern in `RDFParserFactory`
3. updated no-arg constructors in `RDFXMLExtractor` and `TriXExtractor` to match their javadoc specs, along with the behavior all the other RDF extractor classes' no-arg constructors

mvn clean test -> all tests passed

@lewismc any comments before I merge this in?