### PR TITLE
ANY23-366 resolved additional build warnings

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -100,6 +100,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -122,6 +128,16 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- END: Tika -->
 
@@ -213,6 +229,12 @@
     <dependency> <!-- used by RDF4J -->
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-cache</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency> <!-- used by RDF4J -->
       <groupId>org.apache.httpcomponents</groupId>
@@ -221,6 +243,12 @@
     <dependency> <!-- used by RDF4J -->
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency> <!-- used by RDF4J -->
       <groupId>org.apache.httpcomponents</groupId>
@@ -246,7 +274,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency> <!-- used by Tika -->
+    <dependency> <!-- used by Tika, also replaces httpclient commons-logging dependency -->
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -332,7 +332,7 @@
           <programs>
             <program>
               <mainClass>org.apache.any23.cli.ToolRunner</mainClass>
-              <name>any23</name>
+              <id>any23</id>
               <jvmSettings>
                 <maxMemorySize>6000m</maxMemorySize>
               </jvmSettings>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,6 +66,12 @@
     <dependency> <!-- used by RDF4J, Tika -->
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency> <!-- used by RDF4J, Tika -->
       <groupId>org.apache.httpcomponents</groupId>
@@ -78,6 +84,12 @@
     <dependency> <!-- used by RDF4J -->
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-cache</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency> <!-- used by RDF4J -->
       <groupId>org.apache.httpcomponents</groupId>
@@ -86,6 +98,12 @@
     <dependency> <!-- used by RDF4J -->
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency> <!-- used by RDF4J -->
       <groupId>org.apache.httpcomponents</groupId>
@@ -105,6 +123,16 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency> <!-- used by Tika -->
         <groupId>org.apache.commons</groupId>
@@ -253,7 +281,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency> <!-- used by Tika -->
+    <dependency> <!-- used by Tika, also replaces httpclient commons-logging dependency -->
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>

--- a/encoding/pom.xml
+++ b/encoding/pom.xml
@@ -51,6 +51,16 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- ensure dependencies of tika-parsers match versions
       specified in dependencyManagement section of parent pom -->
@@ -77,6 +87,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -111,7 +127,7 @@
       <artifactId>jul-to-slf4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
+      <groupId>org.slf4j</groupId> <!-- also replaces httpclient commons-logging dependency -->
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
     <!-- END: Tika -->

--- a/mime/pom.xml
+++ b/mime/pom.xml
@@ -88,6 +88,16 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- ensure dependencies of tika-parsers match versions
       specified in dependencyManagement section of parent pom -->
@@ -106,6 +116,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -139,7 +155,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>jul-to-slf4j</artifactId>
     </dependency>
-    <dependency>
+    <dependency> <!-- also replaces httpclient commons-logging dependency -->
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>


### PR DESCRIPTION
1. Excluded `commons-logging` from dependencies to ensure `jcl-over-slf4j` works as expected
2. Changed deprecated 'name' tag to 'id' in `appassembler-maven-plugin`