### PR TITLE
Any23 295: Implement ability to use librdfa

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -60,6 +60,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>apache-any23-librdfa</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </dependency>
     <!-- END: Any23 -->
 
     <!-- BEGIN: httpcomponents -->

--- a/core/src/main/java/org/apache/any23/extractor/rdf/RDFParserFactory.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/RDFParserFactory.java
@@ -17,10 +17,16 @@
 
 package org.apache.any23.extractor.rdf;
 
-import org.apache.any23.extractor.IssueReport;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.Collections;
+import java.util.HashSet;
 import org.apache.any23.extractor.ExtractionContext;
 import org.apache.any23.extractor.ExtractionResult;
+import org.apache.any23.extractor.IssueReport;
 import org.apache.any23.rdf.Any23ValueFactoryWrapper;
+import org.apache.any23.rdf.rdfa.LibrdfaRDFaParser;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.ParseErrorListener;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -35,12 +41,6 @@ import org.eclipse.rdf4j.rio.turtle.TurtleParser;
 import org.semanticweb.owlapi.rio.OWLAPIRDFFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.util.Collections;
-import java.util.HashSet;
 
 /**
  * This factory provides a common logic for creating and configuring correctly
@@ -120,6 +120,27 @@ public class RDFParserFactory {
             final ExtractionResult extractionResult
     ) {
         final RDFParser parser = Rio.createParser(RDFFormat.RDFA);
+        parser.getParserConfig().set(RDFaParserSettings.RDFA_COMPATIBILITY, RDFaVersion.RDFA_1_1);
+        configureParser(parser, verifyDataType, stopAtFirstError, extractionContext, extractionResult);
+        return parser;
+    }
+    
+    /**
+     * Returns a new instance of a configured RDFaParser using the librdfa library.
+     *
+     * @param verifyDataType data verification enable if <code>true</code>.
+     * @param stopAtFirstError the parser stops at first error if <code>true</code>.
+     * @param extractionContext the extraction context where the parser is used.
+     * @param extractionResult the output extraction result.
+     * @return a new instance of a configured RDFXML parser.
+     */
+    public RDFParser getRDFaLibrdfaParser(
+            final boolean verifyDataType,
+            final boolean stopAtFirstError,
+            final ExtractionContext extractionContext,
+            final ExtractionResult extractionResult
+    ) {
+        final RDFParser parser = new LibrdfaRDFaParser();
         parser.getParserConfig().set(RDFaParserSettings.RDFA_COMPATIBILITY, RDFaVersion.RDFA_1_1);
         configureParser(parser, verifyDataType, stopAtFirstError, extractionContext, extractionResult);
         return parser;

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/LibRdfaExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/LibRdfaExtractor.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.any23.extractor.rdfa;
+
+import org.apache.any23.extractor.ExtractionContext;
+import org.apache.any23.extractor.ExtractionResult;
+import org.apache.any23.extractor.ExtractorDescription;
+import org.apache.any23.extractor.rdf.BaseRDFExtractor;
+import org.eclipse.rdf4j.rio.RDFParser;
+
+/**
+ *
+ * @author Julio Caguano
+ */
+public class LibRdfaExtractor extends BaseRDFExtractor {
+
+    public LibRdfaExtractor(boolean verifyDataType, boolean stopAtFirstError) {
+        super(verifyDataType, stopAtFirstError);
+    }
+
+    public LibRdfaExtractor() {
+        this(false, false);
+    }
+
+    @Override
+    protected RDFParser getParser(ExtractionContext extractionContext, ExtractionResult extractionResult) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public ExtractorDescription getDescription() {
+        return LibRdfaExtractorFactory.getDescriptionInstance();
+    }
+
+}

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/LibRdfaExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/LibRdfaExtractor.java
@@ -20,6 +20,7 @@ import org.apache.any23.extractor.ExtractionContext;
 import org.apache.any23.extractor.ExtractionResult;
 import org.apache.any23.extractor.ExtractorDescription;
 import org.apache.any23.extractor.rdf.BaseRDFExtractor;
+import org.apache.any23.extractor.rdf.RDFParserFactory;
 import org.eclipse.rdf4j.rio.RDFParser;
 
 /**
@@ -38,7 +39,9 @@ public class LibRdfaExtractor extends BaseRDFExtractor {
 
     @Override
     protected RDFParser getParser(ExtractionContext extractionContext, ExtractionResult extractionResult) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        return RDFParserFactory.getInstance().getRDFaLibrdfaParser(
+                isVerifyDataType(), isStopAtFirstError(), extractionContext, extractionResult
+        );
     }
 
     @Override

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/LibRdfaExtractorFactory.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/LibRdfaExtractorFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.any23.extractor.rdfa;
+
+import java.util.Arrays;
+import org.apache.any23.extractor.ExtractorDescription;
+import org.apache.any23.extractor.ExtractorFactory;
+import org.apache.any23.extractor.SimpleExtractorFactory;
+import org.apache.any23.rdf.Prefixes;
+
+/**
+ *
+ * @author Julio Caguano
+ */
+public class LibRdfaExtractorFactory extends SimpleExtractorFactory<LibRdfaExtractor>
+        implements ExtractorFactory<LibRdfaExtractor> {
+
+    public static final String NAME = "html-librdfa";
+    public static final Prefixes PREFIXES = null;
+
+    private static final ExtractorDescription descriptionInstance = new RDFa11ExtractorFactory();
+
+    public LibRdfaExtractorFactory() {
+        super(RDFa11ExtractorFactory.NAME,
+                RDFa11ExtractorFactory.PREFIXES,
+                Arrays.asList("text/html;q=0.3", "application/xhtml+xml;q=0.3"),
+                "example-rdfa11.html");
+    }
+
+    @Override
+    public LibRdfaExtractor createExtractor() {
+        return new LibRdfaExtractor();
+    }
+
+    public static ExtractorDescription getDescriptionInstance() {
+        return descriptionInstance;
+    }
+}

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/LibRdfaExtractorFactory.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/LibRdfaExtractorFactory.java
@@ -31,11 +31,11 @@ public class LibRdfaExtractorFactory extends SimpleExtractorFactory<LibRdfaExtra
     public static final String NAME = "html-librdfa";
     public static final Prefixes PREFIXES = null;
 
-    private static final ExtractorDescription descriptionInstance = new RDFa11ExtractorFactory();
+    private static final ExtractorDescription descriptionInstance = new LibRdfaExtractorFactory();
 
     public LibRdfaExtractorFactory() {
-        super(RDFa11ExtractorFactory.NAME,
-                RDFa11ExtractorFactory.PREFIXES,
+        super(LibRdfaExtractorFactory.NAME,
+                LibRdfaExtractorFactory.PREFIXES,
                 Arrays.asList("text/html;q=0.3", "application/xhtml+xml;q=0.3"),
                 "example-rdfa11.html");
     }

--- a/core/src/test/java/org/apache/any23/extractor/rdfa/RDFaLibrdfaExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/rdfa/RDFaLibrdfaExtractorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.any23.extractor.rdfa;
 
 import java.io.IOException;
@@ -25,6 +24,7 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -33,8 +33,10 @@ import org.junit.Test;
 public class RDFaLibrdfaExtractorTest extends AbstractRDFaExtractorTestCase {
 
     /**
-     * Taken from the <a href="http://www.heppnetz.de/rdfa4google/testcases.html">GoodRelations test cases</a>.
-     * It checks if the extraction is the same when the namespaces are defined in <i>RDFa1.0</i> or
+     * Taken from the
+     * <a href="http://www.heppnetz.de/rdfa4google/testcases.html">GoodRelations
+     * test cases</a>. It checks if the extraction is the same when the
+     * namespaces are defined in <i>RDFa1.0</i> or
      * <i>RDFa1.1</i> respectively.
      *
      * @throws org.eclipse.rdf4j.repository.RepositoryException
@@ -44,7 +46,7 @@ public class RDFaLibrdfaExtractorTest extends AbstractRDFaExtractorTestCase {
      */
     @Test
     public void testRDFa11PrefixBackwardCompatibility()
-    throws RepositoryException, RDFHandlerException, IOException, RDFParseException {
+            throws RepositoryException, RDFHandlerException, IOException, RDFParseException {
         final int EXPECTED_STATEMENTS = 31;
 
         assertExtract("/html/rdfa/goodrelations-rdfa10.html");
@@ -53,22 +55,23 @@ public class RDFaLibrdfaExtractorTest extends AbstractRDFaExtractorTestCase {
         List<Statement> rdfa10Stmts = dumpAsListOfStatements();
 
         //assertContainsModel("/html/rdfa/goodrelations-rdfa10-expected.nq");
-
         assertExtract("/html/rdfa/goodrelations-rdfa11.html");
         logger.debug("Model 2 " + dumpHumanReadableTriples());
         Assert.assertTrue(dumpAsListOfStatements().size() >= EXPECTED_STATEMENTS);
 
-        for(Statement stmt : rdfa10Stmts) {
+        for (Statement stmt : rdfa10Stmts) {
             assertContains(stmt);
         }
     }
 
     @Test
-    public void testRDFa11CURIEs() throws Exception {
+    @Ignore(value = "ERROR: Corrupted STDOUT by directly writing to native stream in forked JVM 1")
+    public void testBasic() throws Exception {
     }
-	
+
     /**
-     * Tests that the default parser settings enable tolerance in data type parsing.
+     * Tests that the default parser settings enable tolerance in data type
+     * parsing.
      */
     @Test
     public void testTolerantParsing() {

--- a/core/src/test/java/org/apache/any23/extractor/rdfa/RDFaLibrdfaExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/rdfa/RDFaLibrdfaExtractorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.any23.extractor.rdfa;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.any23.extractor.ExtractorFactory;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Reference Test Class for {@link RDFaExtractor}.
+ */
+public class RDFaLibrdfaExtractorTest extends AbstractRDFaExtractorTestCase {
+
+    /**
+     * Taken from the <a href="http://www.heppnetz.de/rdfa4google/testcases.html">GoodRelations test cases</a>.
+     * It checks if the extraction is the same when the namespaces are defined in <i>RDFa1.0</i> or
+     * <i>RDFa1.1</i> respectively.
+     *
+     * @throws org.eclipse.rdf4j.repository.RepositoryException
+     * @throws java.io.IOException
+     * @throws org.eclipse.rdf4j.rio.RDFHandlerException
+     * @throws org.eclipse.rdf4j.rio.RDFParseException
+     */
+    @Test
+    public void testRDFa11PrefixBackwardCompatibility()
+    throws RepositoryException, RDFHandlerException, IOException, RDFParseException {
+        final int EXPECTED_STATEMENTS = 31;
+
+        assertExtract("/html/rdfa/goodrelations-rdfa10.html");
+        logger.debug("Model 1 " + dumpHumanReadableTriples());
+        Assert.assertEquals(EXPECTED_STATEMENTS, dumpAsListOfStatements().size());
+        List<Statement> rdfa10Stmts = dumpAsListOfStatements();
+
+        //assertContainsModel("/html/rdfa/goodrelations-rdfa10-expected.nq");
+
+        assertExtract("/html/rdfa/goodrelations-rdfa11.html");
+        logger.debug("Model 2 " + dumpHumanReadableTriples());
+        Assert.assertTrue(dumpAsListOfStatements().size() >= EXPECTED_STATEMENTS);
+
+        for(Statement stmt : rdfa10Stmts) {
+            assertContains(stmt);
+        }
+    }
+
+    @Test
+    public void testRDFa11CURIEs() throws Exception {
+    }
+	
+    /**
+     * Tests that the default parser settings enable tolerance in data type parsing.
+     */
+    @Test
+    public void testTolerantParsing() {
+        assertExtract("/html/rdfa/oreilly-invalid-datatype.html");
+    }
+
+    @Override
+    protected ExtractorFactory<?> getExtractorFactory() {
+        return new LibRdfaExtractorFactory();
+    }
+
+}


### PR DESCRIPTION
Integration of [librdfa](https://github.com/rdfa/librdfa) on Any23 through the Rio API of RDF4J. For that, I have created a [new parser](https://github.com/JulioCCBUcuenca/librdfa-rdf4j).

In order to try out the PR, you should:

1. Install [librdfa](https://github.com/rdfa/librdfa)
2. Compile [librdfa-rdf4j](https://github.com/JulioCCBUcuenca/librdfa-rdf4j) since is not available in mvn central repository yet.
3. Compile Any23 