### PR TITLE
ANY23-374 fix schemeless microdata urls

### DIFF
--- a/core/src/test/java/org/apache/any23/extractor/microdata/MicrodataExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/microdata/MicrodataExtractorTest.java
@@ -23,6 +23,7 @@ import org.apache.any23.extractor.html.AbstractExtractorTestCase;
 import org.apache.any23.rdf.RDFUtils;
 import org.apache.any23.vocab.SINDICE;
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.junit.Assert;
@@ -81,6 +82,14 @@ public class MicrodataExtractorTest extends AbstractExtractorTestCase {
         assertModelNotEmpty();
         assertStatementsSize(null, null, null, 40);
         assertStatementsSize(RDFUtils.iri("urn:isbn:0-330-34032-8"), null, null, 4);
+    }
+
+    @Test
+    public void testMicrodataMissingScheme() {
+        assertExtract("/microdata/microdata-missing-scheme.html");
+        assertModelNotEmpty();
+        assertContains(null, RDF.TYPE, RDFUtils.iri("http://schema.org/Answer"));
+        System.out.println(dumpHumanReadableTriples());
     }
 
     /**

--- a/test-resources/src/test/resources/microdata/microdata-missing-scheme.html
+++ b/test-resources/src/test/resources/microdata/microdata-missing-scheme.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Missing Scheme</title>
+</head>
+<body>
+
+<div itemscope itemtype="http://schema.org/Question">
+    <h3 itemprop="name">Name</h3>
+    <div itemprop="acceptedAnswer" itemscope itemtype="schema.org/Answer">
+        <p itemprop="text">Text</p>
+    </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Fixes microdata itemtype urls that are lacking a scheme by using a default scheme of "http".

mvn clean test -> all tests passed.