### PR TITLE
ANY23-380 disallow duplicate attribute keys

### DIFF
--- a/cli/src/main/java/org/apache/any23/cli/BaseTool.java
+++ b/cli/src/main/java/org/apache/any23/cli/BaseTool.java
@@ -1,9 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.any23.cli;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 
+/**
+ * This class reduces the verbosity of testing command-line
+ * console output by intercepting the underlying {@link PrintStream}
+ * when applicable and replacing it with a more concise version.
+ *
+ * @author Hans Brende (hansbrende@apache.org)
+ */
 abstract class BaseTool implements Tool {
 
     abstract PrintStream getOut();

--- a/cli/src/main/java/org/apache/any23/cli/BaseTool.java
+++ b/cli/src/main/java/org/apache/any23/cli/BaseTool.java
@@ -1,0 +1,83 @@
+package org.apache.any23.cli;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+abstract class BaseTool implements Tool {
+
+    abstract PrintStream getOut();
+    abstract void setOut(PrintStream out);
+
+    void run(boolean concise) throws Exception {
+        PrintStream out = concise(getOut(), concise);
+        setOut(out);
+        try {
+            run();
+        } finally {
+            close(out);
+        }
+    }
+
+    private static void close(PrintStream stream) {
+        if (stream != null && stream != System.out && stream != System.err) {
+            try {
+                stream.close();
+            } catch (Throwable th) {
+                //ignore
+            }
+        }
+    }
+
+    private static PrintStream concise(PrintStream out, boolean concise) {
+        return (concise && (out == System.out || out == System.err)) ? new ConcisePrintStream(out)
+                : (out instanceof ConcisePrintStream ? ((ConcisePrintStream) out).out : out);
+    }
+
+    private static final class ConcisePrintStream extends PrintStream {
+
+        private PrintStream out;
+
+        private ConcisePrintStream(PrintStream out) {
+            super(new OutputStream() {
+                StringBuilder sb = new StringBuilder();
+                int lineCount;
+                boolean truncated = false;
+                @Override
+                public void write(int b) throws IOException {
+                    if (sb == null) {
+                        throw new IOException("stream closed");
+                    }
+                    if (b == '\n') {
+                        lineCount++;
+                    }
+                    if (lineCount == 0 && sb.length() < 200) {
+                        sb.append((char)b);
+                    } else if (!Character.isWhitespace(b)) {
+                        truncated = true;
+                    }
+                }
+
+                @Override
+                public void close() {
+                    if (sb == null) {
+                        return;
+                    }
+                    if (truncated) {
+                        sb.append("...");
+                    }
+                    if (lineCount > 1) {
+                        sb.append("\n...\n[Suppressed ").append(lineCount).append(" lines of output.]");
+                    }
+
+                    out.println(sb);
+                    sb = null;
+                    BaseTool.close(out);
+                }
+            }, true);
+            this.out = out;
+        }
+
+    }
+
+}

--- a/cli/src/main/java/org/apache/any23/cli/ExtractorDocumentation.java
+++ b/cli/src/main/java/org/apache/any23/cli/ExtractorDocumentation.java
@@ -30,13 +30,14 @@ import org.apache.any23.extractor.ExtractorFactory;
 import org.apache.any23.extractor.ExtractorRegistry;
 
 import java.io.IOException;
+import java.io.PrintStream;
 
 /**
  * This class provides some command-line documentation
  * about available extractors and their usage.
  */
 @Parameters( commandNames = { "extractor" }, commandDescription= "Utility for obtaining documentation about metadata extractors.")
-public class ExtractorDocumentation implements Tool {
+public class ExtractorDocumentation extends BaseTool {
 
     @Parameter( names = { "-l", "--list" }, description = "shows the names of all available extractors" )
     private boolean showList;
@@ -50,6 +51,19 @@ public class ExtractorDocumentation implements Tool {
     @Parameter( names = { "-a", "--all" }, description = "shows a report about all available extractors" )
     private boolean showAll;
 
+    private PrintStream out = System.out;
+
+    @Override
+    PrintStream getOut() {
+        return out;
+    }
+
+    @Override
+    void setOut(PrintStream out) {
+        this.out = out;
+    }
+
+    @Override
     public void run() throws Exception {
         if (showList) {
             printExtractorList(ExtractorRegistryImpl.getInstance());
@@ -78,7 +92,7 @@ public class ExtractorDocumentation implements Tool {
      */
     public void printExtractorList(ExtractorRegistry registry) {
         for (ExtractorFactory factory : registry.getExtractorGroup()) {
-            System.out.println( String.format("%25s [%15s]", factory.getExtractorName(), factory.getExtractorLabel()));
+            out.println(String.format("%25s [%15s]", factory.getExtractorName(), factory.getExtractorLabel()));
         }
     }
 
@@ -97,7 +111,7 @@ public class ExtractorDocumentation implements Tool {
         if (input == null) {
             throw new IllegalArgumentException("Extractor " + extractorName + " provides no example input");
         }
-        System.out.println(input);
+        out.println(input);
     }
 
     /**
@@ -116,7 +130,7 @@ public class ExtractorDocumentation implements Tool {
         if (output == null) {
             throw new IllegalArgumentException("Extractor " + extractorName + " provides no example output");
         }
-        System.out.println(output);
+        out.println(output);
     }
 
     /**
@@ -131,21 +145,21 @@ public class ExtractorDocumentation implements Tool {
         for (String extractorName : registry.getAllNames()) {
             ExtractorFactory<?> factory = registry.getFactory(extractorName);
             ExampleInputOutput example = new ExampleInputOutput(factory);
-            System.out.println("Extractor: " + extractorName);
-            System.out.println("\ttype: " + getType(factory));
-            System.out.println();
+            out.println("Extractor: " + extractorName);
+            out.println("\ttype: " + getType(factory));
+            out.println();
             final String exampleInput = example.getExampleInput();
-            if(exampleInput == null) {
-                System.out.println("(No Example Available)");
+            if (exampleInput == null) {
+                out.println("(No Example Available)");
             } else {
-                System.out.println("-------- Example Input  --------");
-                System.out.println(exampleInput);
-                System.out.println("-------- Example Output --------");
+                out.println("-------- Example Input  --------");
+                out.println(exampleInput);
+                out.println("-------- Example Output --------");
                 String output = example.getExampleOutput();
-                System.out.println(output == null || output.trim().length() == 0 ? "(No Output Generated)" : output);
+                out.println(output == null || output.trim().length() == 0 ? "(No Output Generated)" : output);
             }
-            System.out.println("================================");
-            System.out.println();
+            out.println("================================");
+            out.println();
         }
     }
 

--- a/cli/src/main/java/org/apache/any23/cli/MicrodataParser.java
+++ b/cli/src/main/java/org/apache/any23/cli/MicrodataParser.java
@@ -30,6 +30,7 @@ import org.apache.any23.util.StreamUtils;
 
 import java.io.File;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.net.URISyntaxException;
 import java.util.LinkedList;
 import java.util.List;
@@ -44,7 +45,7 @@ import java.util.regex.Pattern;
  * @author Michele Mostarda (mostarda@fbk.eu)
  */
 @Parameters( commandNames = { "microdata" },  commandDescription = "Commandline Tool for extracting Microdata from file/HTTP source.")
-public class MicrodataParser implements Tool {
+public class MicrodataParser extends BaseTool {
 
     private static final Pattern HTTP_DOCUMENT_PATTERN = Pattern.compile("^https?://.*");
 
@@ -56,6 +57,18 @@ public class MicrodataParser implements Tool {
        converter = MicrodataParserDocumentSourceConverter.class
     )
     private List<DocumentSource> document = new LinkedList<DocumentSource>();
+
+    private PrintStream out = System.out;
+
+    @Override
+    PrintStream getOut() {
+        return out;
+    }
+
+    @Override
+    void setOut(PrintStream out) {
+        this.out = out;
+    }
 
     public void run() throws Exception {
         if (document.isEmpty()) {
@@ -69,7 +82,7 @@ public class MicrodataParser implements Tool {
                     documentInputInputStream,
                     documentSource.getDocumentIRI()
             );
-            org.apache.any23.extractor.microdata.MicrodataParser.getMicrodataAsJSON(tagSoupParser.getDOM(), System.out);
+            org.apache.any23.extractor.microdata.MicrodataParser.getMicrodataAsJSON(tagSoupParser.getDOM(), out);
         } finally {
             if (documentInputInputStream != null) StreamUtils.closeGracefully(documentInputInputStream);
         }

--- a/cli/src/main/java/org/apache/any23/cli/MimeDetector.java
+++ b/cli/src/main/java/org/apache/any23/cli/MimeDetector.java
@@ -32,6 +32,7 @@ import org.apache.any23.source.HTTPDocumentSource;
 import org.apache.any23.source.StringDocumentSource;
 
 import java.io.File;
+import java.io.PrintStream;
 import java.net.URISyntaxException;
 import java.util.LinkedList;
 import java.util.List;
@@ -44,7 +45,7 @@ import java.util.List;
  * @author Michele Mostarda (mostarda@fbk.eu)
  */
 @Parameters(commandNames = { "mimes" }, commandDescription = "MIME Type Detector Tool.")
-public class MimeDetector implements Tool{
+public class MimeDetector extends BaseTool {
 
     public static final String FILE_DOCUMENT_PREFIX   = "file://";
 
@@ -59,6 +60,18 @@ public class MimeDetector implements Tool{
     )
     private List<DocumentSource> document = new LinkedList<DocumentSource>();
 
+    private PrintStream out = System.out;
+
+    @Override
+    PrintStream getOut() {
+        return out;
+    }
+
+    @Override
+    void setOut(PrintStream out) {
+        this.out = out;
+    }
+
     public void run() throws Exception {
         if (document.isEmpty()) {
             throw new IllegalArgumentException("No input document URL specified");
@@ -71,7 +84,7 @@ public class MimeDetector implements Tool{
                 documentSource.openInputStream(),
                 MIMEType.parse(documentSource.getContentType())
         );
-        System.out.println(mimeType);
+        out.println(mimeType);
     }
 
     public static final class MimeDetectorDocumentSourceConverter implements IStringConverter<DocumentSource> {

--- a/cli/src/main/java/org/apache/any23/cli/PluginVerifier.java
+++ b/cli/src/main/java/org/apache/any23/cli/PluginVerifier.java
@@ -38,7 +38,7 @@ import java.util.List;
  * @author Michele Mostarda (mostarda@fbk.eu)
  */
 @Parameters(commandNames = { "verify" }, commandDescription = "Utility for plugin management verification.")
-public class PluginVerifier implements Tool {
+public class PluginVerifier extends BaseTool {
 
     private Any23PluginManager pluginManager = Any23PluginManager.getInstance();
 
@@ -47,6 +47,18 @@ public class PluginVerifier implements Tool {
         converter = FileConverter.class
     )
     private List<File> pluginsDirs = new LinkedList<>();
+
+    private PrintStream out = System.out;
+
+    @Override
+    PrintStream getOut() {
+        return out;
+    }
+
+    @Override
+    void setOut(PrintStream out) {
+        this.out = out;
+    }
 
     public void run() throws Exception {
         if (pluginsDirs.isEmpty()) {
@@ -63,8 +75,8 @@ public class PluginVerifier implements Tool {
         final Iterator<ExtractorFactory> plugins = pluginManager.getExtractors();
 
         while (plugins.hasNext()) {
-            printPluginData(plugins.next(), System.out);
-            System.out.println("------------------------------------------------------------------------");
+            printPluginData(plugins.next(), out);
+            out.println("------------------------------------------------------------------------");
         }
     }
 

--- a/cli/src/main/java/org/apache/any23/cli/Rover.java
+++ b/cli/src/main/java/org/apache/any23/cli/Rover.java
@@ -59,7 +59,7 @@ import static java.lang.String.format;
  * @author Gabriele Renzi
  */
 @Parameters(commandNames = { "rover" }, commandDescription = "Any23 Command Line Tool.")
-public class Rover implements Tool {
+public class Rover extends BaseTool {
 
     private static final List<String> FORMATS = WriterFactoryRegistry.getInstance().getIdentifiers();
 
@@ -116,6 +116,16 @@ public class Rover implements Tool {
     private Any23 any23;
 
     private ExtractionParameters extractionParameters;
+
+    @Override
+    PrintStream getOut() {
+        return outputStream;
+    }
+
+    @Override
+    void setOut(PrintStream out) {
+        outputStream = out;
+    }
 
     protected void configure() {
         try {

--- a/cli/src/main/java/org/apache/any23/cli/ToolRunner.java
+++ b/cli/src/main/java/org/apache/any23/cli/ToolRunner.java
@@ -69,7 +69,11 @@ public final class ToolRunner {
         exit( new ToolRunner().execute( args ) );
     }
 
-    public int execute(String...args) throws Exception {
+    public int execute(String... args) throws Exception {
+        return execute(false, args);
+    }
+
+    int execute(boolean concise, String... args) throws Exception {
         JCommander commander = new JCommander(this);
         commander.setProgramName(System.getProperty("app.name"));
 
@@ -133,7 +137,12 @@ public final class ToolRunner {
         infoStream.println();
 
         try {
-            Tool.class.cast( commands.get( parsedCommand ).getObjects().get( 0 ) ).run();
+            Tool tool = Tool.class.cast(commands.get(parsedCommand).getObjects().get(0));
+            if (tool instanceof BaseTool) {
+                ((BaseTool) tool).run(concise);
+            } else {
+                tool.run();
+            }
         } catch (Throwable t) {
             exit = 1;
             error = t;

--- a/cli/src/main/java/org/apache/any23/cli/VocabPrinter.java
+++ b/cli/src/main/java/org/apache/any23/cli/VocabPrinter.java
@@ -26,19 +26,33 @@ import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 
+import java.io.PrintStream;
+
 /**
  * Prints out the vocabulary <i>RDFSchema</i> as <i>NQuads</i>.
  * 
  * @author Michele Mostarda (mostarda@fbk.eu)
  */
 @Parameters(commandNames = { "vocab" }, commandDescription = "Prints out the RDF Schema of the vocabularies used by Any23.")
-public class VocabPrinter implements Tool {
+public class VocabPrinter extends BaseTool {
 
     @Parameter(names = { "-f", "--format" }, description = "Vocabulary output format", converter = RDFFormatConverter.class)
     private RDFFormat format = RDFFormat.NQUADS;
 
+    private PrintStream out = System.out;
+
+    @Override
+    PrintStream getOut() {
+        return out;
+    }
+
+    @Override
+    void setOut(PrintStream out) {
+        this.out = out;
+    }
+
     public void run() throws Exception {
-        RDFSchemaUtils.serializeVocabularies(format, System.out);
+        RDFSchemaUtils.serializeVocabularies(format, out);
     }
 
     public static final class RDFFormatConverter implements

--- a/cli/src/test/java/org/apache/any23/cli/MicrodataParserTest.java
+++ b/cli/src/test/java/org/apache/any23/cli/MicrodataParserTest.java
@@ -32,7 +32,7 @@ public class MicrodataParserTest extends ToolTestBase {
 
     @Test
     public void testRunOnFile() throws Exception {
-        runToolCheckExit0("file:"+copyResourceToTempFile("/microdata/microdata-nested.html").getAbsolutePath());
+        runToolCheckExit0("file:" + copyResourceToTempFile("/microdata/microdata-nested.html").getAbsolutePath());
     }
 
     @Test

--- a/cli/src/test/java/org/apache/any23/cli/MimeDetectorTest.java
+++ b/cli/src/test/java/org/apache/any23/cli/MimeDetectorTest.java
@@ -39,13 +39,13 @@ public class MimeDetectorTest extends ToolTestBase {
     @Test
     public void testDetectFile() throws Exception {
         assumeOnlineAllowed();
-        runToolCheckExit0("file://"+copyResourceToTempFile("/application/trix/test1.trx").getAbsolutePath());
+        runToolCheckExit0("file://" + copyResourceToTempFile("/application/trix/test1.trx").getAbsolutePath());
     }
 
     @Test
     public void testDetectInline() throws Exception {
         assumeOnlineAllowed();
-        runToolCheckExit0( new String[] {"inline://<http://s> <http://p> <http://o> ."} );
+        runToolCheckExit0("inline://<http://s> <http://p> <http://o> .");
     }
 
 }

--- a/cli/src/test/java/org/apache/any23/cli/RoverTest.java
+++ b/cli/src/test/java/org/apache/any23/cli/RoverTest.java
@@ -28,7 +28,6 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.rio.RDFFormat;
 
 import java.io.File;
-import java.util.Arrays;
 
 /**
  * Test case for {@link Rover}.
@@ -130,7 +129,6 @@ public class RoverTest extends ToolTestBase {
 
         final String outNQuads = FileUtils.readFileContent(outFile);
         final Statement[] statements = RDFUtils.parseRDF(RDFFormat.NQUADS, outNQuads);
-        System.out.println(Arrays.toString(statements));
         Assert.assertTrue("Unexpected number of statements.", statements.length > 9);
     }
 

--- a/cli/src/test/java/org/apache/any23/cli/SimpleRoverTest.java
+++ b/cli/src/test/java/org/apache/any23/cli/SimpleRoverTest.java
@@ -16,12 +16,13 @@
  */
 package org.apache.any23.cli;
 
-import com.google.common.io.Files;
 import java.io.File;
+import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
-import org.apache.any23.util.FileUtils;
-import org.apache.pdfbox.util.Charsets;
+
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,7 +39,7 @@ import org.slf4j.LoggerFactory;
 public class SimpleRoverTest extends ToolTestBase {
     
     private static final String baseUri = "urn:test";
-    private static final Logger log = LoggerFactory.getLogger(SimpleRoverTest.class);
+    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     
     private String filePath;
     
@@ -57,8 +58,7 @@ public class SimpleRoverTest extends ToolTestBase {
     }
 
     /**
-     * Ref {@link https://issues.apache.org/jira/browse/ANY23-310} unit test.
-     * @throws Exception 
+     * Ref <a href="https://issues.apache.org/jira/browse/ANY23-310">ANY23-310</a> unit test.
      */
     @Test
     public void ref310Test()
@@ -75,20 +75,23 @@ public class SimpleRoverTest extends ToolTestBase {
         Assert.assertTrue(logfile.exists());
         Assert.assertTrue(outputFile.exists());
         // check if output file is longer than 10 chracters
-        String outputFileContent = FileUtils.readFileContent(outputFile);
+        String outputFileContent = FileUtils.readFileToString(outputFile, StandardCharsets.UTF_8);
         Assert.assertTrue(outputFileContent.length() > 10);
         
-        String[] logFileContent = FileUtils.readFileLines(logfile);
-        Assert.assertTrue(logFileContent.length == 2);
+        String[] logFileContent = FileUtils.readLines(logfile, StandardCharsets.UTF_8).toArray(new String[0]);
+        Assert.assertEquals(2, logFileContent.length);
         //Assert.assertTrue(logFileContent[1].split("\\W*")[1] == );
         int contentSize = Integer.valueOf(logFileContent[1].split("\\t")[1]);
-        log.info("Content: '{}'", contentSize);
         String extractors = logFileContent[1].split("\\t")[4].replaceAll("[\\[\\]\\s:\\d]", "");
-        log.info("Extractors: '{}'", extractors);
-        
-        
-        log.debug("Log file location: {}", logfile.getAbsolutePath());
-        log.trace("Log file content: \n{}\n", Files.toString(logfile, Charsets.UTF_8));
+
+        if (log.isDebugEnabled()) {
+            log.debug("Content: '{}'", contentSize);
+            log.debug("Extractors: '{}'", extractors);
+            log.debug("Log file location: {}", logfile.getAbsolutePath());
+        }
+        if (log.isTraceEnabled()) {
+            log.trace("Log file content: \n{}\n", FileUtils.readFileToString(logfile, StandardCharsets.UTF_8));
+        }
 
         Assert.assertTrue("Content size should be greated than 0", contentSize > 0);
         Assert.assertFalse(extractors.isEmpty());
@@ -96,12 +99,11 @@ public class SimpleRoverTest extends ToolTestBase {
     }
     
     /**
-     * Ref {@link https://issues.apache.org/jira/browse/ANY23-310} unit test.
+     * Ref <a href="https://issues.apache.org/jira/browse/ANY23-310">ANY23-310</a> unit test.
      * 
      * Example without the logging file.
      * 
      * By default that test is not active. It might be useful for debugging.
-     * @throws Exception 
      */
     @Test
     public void ref310ExtendedTest()
@@ -115,7 +117,7 @@ public class SimpleRoverTest extends ToolTestBase {
         
         Assert.assertTrue(outputFile.exists());
         // check if output file is longer than 10 chracters
-        String outputFileContent = FileUtils.readFileContent(outputFile);
+        String outputFileContent = FileUtils.readFileToString(outputFile, StandardCharsets.UTF_8);
         Assert.assertTrue(outputFileContent.length() > 10);
         
         

--- a/cli/src/test/java/org/apache/any23/cli/ToolTestBase.java
+++ b/cli/src/test/java/org/apache/any23/cli/ToolTestBase.java
@@ -21,6 +21,7 @@ import com.beust.jcommander.Parameters;
 import org.apache.any23.Any23OnlineTestBase;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
@@ -30,7 +31,6 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Michele Mostarda (mostarda@fbk.eu)
  */
-// TODO: improve support for Tool testing, intercept i/o streams.
 public abstract class ToolTestBase extends Any23OnlineTestBase {
 
     public static final String TOOL_RUN_METHOD = "run";
@@ -38,8 +38,7 @@ public abstract class ToolTestBase extends Any23OnlineTestBase {
     private final Class<? extends Tool> toolClazz;
 
     protected ToolTestBase(Class<? extends Tool> tool) {
-        if (tool == null) throw new NullPointerException();
-        toolClazz = tool;
+        toolClazz = Objects.requireNonNull(tool, "Tool class cannot be null.");
     }
 
     /**
@@ -56,7 +55,7 @@ public abstract class ToolTestBase extends Any23OnlineTestBase {
         enhancedArgs[0] = commandName;
         System.arraycopy( args, 0, enhancedArgs, 1, args.length );
 
-        return new ToolRunner().execute( enhancedArgs );
+        return new ToolRunner().execute(true, enhancedArgs);
     }
 
     /**

--- a/cli/src/test/java/org/apache/any23/cli/YAMLRoverTest.java
+++ b/cli/src/test/java/org/apache/any23/cli/YAMLRoverTest.java
@@ -16,10 +16,11 @@
  */
 package org.apache.any23.cli;
 
-import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
-import org.apache.pdfbox.util.Charsets;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -56,7 +57,7 @@ public class YAMLRoverTest extends ToolTestBase {
 
         Assert.assertTrue(logfile.exists());
         log.debug("Log file location: {}", logfile.getAbsolutePath());
-        log.info("Log file content: \n{}\n", Files.toString(logfile, Charsets.UTF_8));
+        log.debug("Log file content: \n{}\n", FileUtils.readFileToString(logfile, StandardCharsets.UTF_8));
 
         Assert.assertEquals("Unexpected exit code.", 0, exitCode);
         assertFileContainsString(outputFile, baseUri);
@@ -72,7 +73,7 @@ public class YAMLRoverTest extends ToolTestBase {
      * @return
      */
     public void assertFileContainsString(File f, String s) throws IOException {
-        String fileContent = Files.toString(f, Charsets.UTF_8);
+        String fileContent = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
         log.trace("File content: \n{}\n", fileContent);
         Assert.assertTrue(fileContent.contains(s));
     }

--- a/core/src/main/java/org/apache/any23/extractor/SingleDocumentExtraction.java
+++ b/core/src/main/java/org/apache/any23/extractor/SingleDocumentExtraction.java
@@ -218,8 +218,8 @@ public class SingleDocumentExtraction {
         } catch (Exception ex) {
             throw new IllegalArgumentException("Invalid IRI: " + in.getDocumentIRI(), ex);
         }
-        if(log.isInfoEnabled()) {
-            log.info("Processing " + this.documentIRI);
+        if (log.isDebugEnabled()) {
+            log.debug("Processing " + this.documentIRI);
         }
         filterExtractorsByMIMEType();
 

--- a/core/src/main/java/org/apache/any23/extractor/rdf/BaseRDFExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/BaseRDFExtractor.java
@@ -46,6 +46,7 @@ import java.io.InputStream;
 import java.io.PushbackInputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.regex.Pattern;
 
@@ -131,26 +132,43 @@ public abstract class BaseRDFExtractor implements Extractor.ContentExtractor {
                 // See https://issues.apache.org/jira/browse/ANY23-317
                 // and https://issues.apache.org/jira/browse/ANY23-340
                 NodeTraversor.filter(new NodeFilter() {
+                    final HashSet<String> tmpAttributeKeys = new HashSet<>();
+
                     @Override
                     public FilterResult head(Node node, int depth) {
                         if (node instanceof Element) {
+                            HashSet<String> attributeKeys = tmpAttributeKeys;
                             for (Iterator<Attribute> it = node.attributes().iterator(); it.hasNext(); ) {
                                 // fix for ANY23-350: valid xml attribute names are ^[a-zA-Z_:][-a-zA-Z0-9_:.]
                                 Attribute attr = it.next();
-                                String key = attr.getKey().replaceAll("[^-a-zA-Z0-9_:.]", "");
+                                String oldKey = attr.getKey();
+                                String newKey = oldKey.replaceAll("[^-a-zA-Z0-9_:.]", "");
 
-                                // fix for ANY23-347: strip xml namespaces
-                                int prefixlen = key.lastIndexOf(':') + 1;
-                                String prefix = key.substring(0, prefixlen).toLowerCase();
-                                key = (prefix.equals("xmlns:") || prefix.equals("xml:") ? prefix : "")
-                                        + key.substring(prefixlen);
+                                // fix for ANY23-347: strip non-reserved xml namespaces
+                                // See https://www.w3.org/TR/xml-names/#sec-namespaces
+                                // "All other prefixes beginning with the three-letter sequence x, m, l,
+                                // in any case combination, are reserved. This means that:
+                                //   * users SHOULD NOT use them except as defined by later specifications
+                                //   * processors MUST NOT treat them as fatal errors."
+                                int prefixlen = oldKey.lastIndexOf(':') + 1;
+                                String prefix = newKey.substring(0, prefixlen).toLowerCase();
+                                newKey = (prefix.startsWith("xml") ? prefix : "") + newKey.substring(prefixlen);
 
-                                if (key.matches("[a-zA-Z_:][-a-zA-Z0-9_:.]*")) {
-                                    attr.setKey(key);
+                                if (newKey.matches("[a-zA-Z_:][-a-zA-Z0-9_:.]*")
+                                        //the namespace name for "xmlns" MUST NOT be declared
+                                        //the namespace name for "xml" need not be declared
+                                        && !newKey.startsWith("xmlns:xml")
+                                        // fix for ANY23-380: disallow duplicate attribute keys
+                                        && attributeKeys.add(newKey)) {
+                                    //avoid indexOf() operation if possible
+                                    if (!newKey.equals(oldKey)) {
+                                        attr.setKey(newKey);
+                                    }
                                 } else {
                                     it.remove();
                                 }
                             }
+                            attributeKeys.clear();
 
                             String tagName = ((Element)node).tagName().replaceAll("[^-a-zA-Z0-9_:.]", "");
                             tagName = tagName.substring(tagName.lastIndexOf(':') + 1);

--- a/core/src/test/java/org/apache/any23/extractor/html/AbstractExtractorTestCase.java
+++ b/core/src/test/java/org/apache/any23/extractor/html/AbstractExtractorTestCase.java
@@ -48,9 +48,12 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -62,6 +65,8 @@ import java.util.Map;
  * specific test cases.
  */
 public abstract class AbstractExtractorTestCase extends AbstractAny23TestBase {
+
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   /**
    * Base test document.
@@ -363,11 +368,11 @@ public abstract class AbstractExtractorTestCase extends AbstractAny23TestBase {
     for (Map.Entry<String, Collection<IssueReport.Issue>> entry : report
             .getExtractorToIssues().entrySet()) {
       if (entry.getValue().size() > 0) {
-        System.out.println("Unexpected issue for extractor " + entry.getKey()
+        log.debug("Unexpected issue for extractor " + entry.getKey()
         + " : " + entry.getValue());
       }
-      for(Issue nextIssue : entry.getValue()) {
-        if(nextIssue.getLevel() == IssueLevel.ERROR || nextIssue.getLevel() == IssueLevel.FATAL) {
+      for (Issue nextIssue : entry.getValue()) {
+        if (nextIssue.getLevel() == IssueLevel.ERROR || nextIssue.getLevel() == IssueLevel.FATAL) {
           Assert.fail("Unexpected issue for extractor " + entry.getKey()
           + " : " + entry.getValue());
         }

--- a/core/src/test/java/org/apache/any23/extractor/rdfa/RDFa11ExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/rdfa/RDFa11ExtractorTest.java
@@ -77,6 +77,12 @@ public class RDFa11ExtractorTest extends AbstractRDFaExtractorTestCase {
     }
 
     @Test
+    public void testAttributeAlreadySpecified() {
+        assertExtract("/html/rdfa/attribute-already-specified.html");
+        assertModelNotEmpty();
+    }
+
+    @Test
     public void test0087() {
         assertExtract("/html/rdfa/0087.xhtml");
         assertModelNotEmpty();

--- a/core/src/test/java/org/apache/any23/extractor/rdfa/RDFa11ExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/rdfa/RDFa11ExtractorTest.java
@@ -292,7 +292,7 @@ public class RDFa11ExtractorTest extends AbstractRDFaExtractorTestCase {
     @Test
     public void testOpenGraphStructuredProperties() throws IOException, ExtractionException, RepositoryException {
         assertExtract("/html/rdfa/opengraph-structured-properties.html");
-        logger.info( dumpHumanReadableTriples() );
+        logger.debug(dumpHumanReadableTriples());
 
         Assert.assertEquals(31, getStatementsSize(null, null, null) );
         final OGP vOGP = OGP.getInstance();
@@ -328,7 +328,7 @@ public class RDFa11ExtractorTest extends AbstractRDFaExtractorTestCase {
     @Test
     public void testOpenGraphAlternateObjectTypes() throws IOException, ExtractionException, RepositoryException {
         assertExtract("/html/rdfa/opengraph-music-song-object-type.html");
-        logger.info( dumpHumanReadableTriples() );
+        logger.debug(dumpHumanReadableTriples());
 
         Assert.assertEquals(9, getStatementsSize(null, null, null) );
         final OGPMusic vOGPMusic = OGPMusic.getInstance();

--- a/core/src/test/java/org/apache/any23/vocab/RDFSchemaUtilsTest.java
+++ b/core/src/test/java/org/apache/any23/vocab/RDFSchemaUtilsTest.java
@@ -39,7 +39,7 @@ public class RDFSchemaUtilsTest {
     /**
      * Test case for
      * {@link RDFSchemaUtils#serializeVocabularies(
-     * org.apache.any23.vocab.RDFSchemaUtils.VocabularyFormat, java.io.PrintStream)} with <i>NTriples</i> format.
+     * org.eclipse.rdf4j.rio.RDFFormat, java.io.PrintStream)} with <i>NTriples</i> format.
      */
     @Test
     public void testSerializeVocabulariesNTriples() {
@@ -49,7 +49,7 @@ public class RDFSchemaUtilsTest {
     /**
      * Test case for
      * {@link RDFSchemaUtils#serializeVocabularies(
-     * org.apache.any23.vocab.RDFSchemaUtils.VocabularyFormat, java.io.PrintStream)} with <i>RDFXML</i> format.
+     * org.eclipse.rdf4j.rio.RDFFormat, java.io.PrintStream)} with <i>RDFXML</i> format.
      */
     @Test
     public void testSerializeVocabulariesRDFXML() {
@@ -58,12 +58,12 @@ public class RDFSchemaUtilsTest {
 
     private void serializeVocabularies(RDFFormat format, int expectedLines) {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final PrintStream ps = new PrintStream(baos);
-        RDFSchemaUtils.serializeVocabularies(format, ps);
-        ps.close();
+        try (PrintStream ps = new PrintStream(baos)) {
+            RDFSchemaUtils.serializeVocabularies(format, ps);
+        }
         final String output = baos.toString();
         logger.debug(output);
-        final int occurrences= StringUtils.countOccurrences(output, "\n");
+        final int occurrences = StringUtils.countOccurrences(output, "\n");
         Assert.assertEquals(expectedLines, occurrences);
     }
 

--- a/plugins/office-scraper/src/test/java/org/apache/any23/plugin/officescraper/ExcelExtractorTest.java
+++ b/plugins/office-scraper/src/test/java/org/apache/any23/plugin/officescraper/ExcelExtractorTest.java
@@ -94,7 +94,7 @@ public class ExcelExtractorTest {
         );
         extractor.run(extractionParameters, extractionContext, is, extractionResult);
         compositeTripleHandler.close();
-        logger.info(out.toString());
+        logger.debug(out.toString());
 
         verifyPredicateOccurrence(verifierTripleHandler, Excel.getInstance().containsSheet, 2 );
         verifyPredicateOccurrence(verifierTripleHandler, Excel.getInstance().containsRow  , 6 );

--- a/test-resources/src/test/resources/html/rdfa/attribute-already-specified.html
+++ b/test-resources/src/test/resources/html/rdfa/attribute-already-specified.html
@@ -1,0 +1,567 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Original page source: https://www.lokalkompass.de/bilder/kirche.html -->
+<html xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="de-DE">
+<head>
+    <title>Bilder kirche: 554 gut bewertete Fotos der Lokalkompass B&uuml;rgerreporter</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="language" content="de" />
+    <meta http-equiv="content-language" content="de" />
+    <meta name="author" content="Westdeutsche Verlags- und Werbegesellschaft mbH &amp; Co. KG " />
+    <meta name="publisher" content="Westdeutsche Verlags- und Werbegesellschaft mbH &amp; Co. KG " />
+    <meta name="robots" content="all" />
+    <meta name="language" content="deutsch, de" />
+    <meta name="google-site-verification" content="d0y-aTF74C7fbvTMPOs8y1e2a9L9D-pK1hdqz_nfldg" />
+    <meta name="msvalidate.01" content="1F5E2D50E7AB0B23071EBF91C95B5017" />
+    <meta name="y_key" content="20d7e954309ba50e" />
+    <meta name="description" content="St&ouml;bern Sie durch die von der Lokalkompass Community gut bewerteten Bilder zum Thema kirche und laden Sie eigene Bilder hoch!" />
+    <meta property="og:title" content="Bilder kirche: 554 gut bewertete Fotos der Lokalkompass B&uuml;rgerreporter" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://www.lokalkompass.de/theme/resources/images/logo_open_graph.png?20180322" />
+    <meta property="og:url" content="https://www.lokalkompass.de/bilder/kirche.html" />
+    <meta property="og:site_name" content="lokalkompass.de" />
+    <meta property="og:description" content="St&ouml;bern Sie durch die von der Lokalkompass Community gut bewerteten Bilder zum Thema kirche und laden Sie eigene Bilder hoch!" />
+
+    <link rel="icon" href="https://www.lokalkompass.de/theme/resources/images/favicon.ico?20100310" type="image/vnd.microsoft.icon" />
+    <link rel="next" href="https://www.lokalkompass.de/bilder/kirche.html/action/page/2/" title="" type="" media="" />
+    <link media="all" href="https://www.lokalkompass.de/tmp/css/default-68e52f90b8165aa4356b57af241b06d0.css" type="text/css" rel="stylesheet" />
+    <script type="text/javascript">
+		var baseURI = "https://www.lokalkompass.de/"; var realmID = 0; var stateID = 0;
+		var ajaxPhpScriptPath = "https://www.lokalkompass.de/ajax/"; var clientId = "";
+		var lokstadt = '';
+		var loktype = '';
+	</script>
+    <!-- Definition von site und zone -->
+    <script>
+			var oms_site = 'oms.lokalkompass.de',
+				oms_zone = 'sonstiges';
+		</script>
+
+    <!-- Integration des container-tags und des google-scriptes -->
+    <script type="text/javascript" src="//www.video.oms.eu/ada/cloud/omsv_container_151.js" charset="UTF-8"></script>
+    <script type="text/javascript">
+			var adlWallPaperLeft = 1010;
+			var googletag = googletag || {};
+			googletag.cmd = googletag.cmd || [];
+			(function() {
+				var gads = document.createElement("script");
+				gads.async = true;
+				gads.type = "text/javascript";
+				var useSSL = "https:" == document.location.protocol;
+				gads.src = (useSSL ? "https:" : "http:") + "//www.googletagservices.com/tag/js/gpt.js";
+				var node = document.getElementsByTagName("script")[0];
+				node.parentNode.insertBefore(gads, node);
+			})();
+		</script>
+    <script>
+			/* Definition der Ad-Positionen */
+			googletag.cmd.push(function() {
+
+				googletag.defineSlot('/5766/'+oms_site+'/'+oms_zone, [[728, 90],[800, 251]], 'oms_superbanner').addService(googletag.pubads());
+googletag.defineSlot('/5766/'+oms_site+'/'+oms_zone, [[120, 600],[160, 600],[200, 600]], 'oms_skyscraper').addService(googletag.pubads());
+googletag.defineSlot('/5766/'+oms_site+'/'+oms_zone, [[960, 150],[800, 250]], 'oms_billboard').addService(googletag.pubads());
+googletag.defineOutOfPageSlot('/5766/'+oms_site+'/'+oms_zone, 'oms_ist').addService(googletag.pubads());
+
+				googletag.pubads().setTargeting('bundesland', 'NW');
+				googletag.pubads().setTargeting('lokstadt', lokstadt);
+				googletag.pubads().setTargeting('lokthema', '');
+				googletag.pubads().setTargeting('loktype', loktype);
+				googletag.pubads().setTargeting('lokrubrik', '');
+				googletag.pubads().setTargeting('lokebene', '0');
+				googletag.pubads().setTargeting('lokid', '');
+				googletag.pubads().collapseEmptyDivs(true, true);
+				googletag.pubads().enableSingleRequest();
+				googletag.enableServices();
+
+				if (typeof googletag != 'undefined' && typeof OMSVad != 'undefined' && OMSVad.WLRCMDGPT != null && !OMSVad.isSetGTarget) {
+					for (var i in OMSVad.WLRCMDGPT) {
+						if (OMSVad.WLRCMDGPT.hasOwnProperty(i)) {
+							googletag.pubads().setTargeting(i, OMSVad.WLRCMDGPT[i]);
+						}
+					}
+					OMSVad.isSetGTarget = true;
+				}
+			});
+		</script>
+
+    <script type="text/javascript">
+            (function() {
+                var s = document.createElement('script');
+                s.type = 'text/javascript';
+                s.async = true;
+                s.src = document.location.protocol + '//cdn.nativendo.de/nativendo.js';
+                var sc = document.getElementsByTagName('script')[0];
+                sc.parentNode.insertBefore(s, sc);
+            })();
+        </script>
+    <script type="text/javascript">
+		window.cookieconsent_options = {"message":"Durch Nutzung dieser Website stimmen Sie der Verwendung von Cookies für Analysen, personalisierte Inhalte und Werbung zu. Weitere Informationen über Cookies finden Sie in unserer ","dismiss":"Akzeptieren","learnMore":"Datenschutzerklärung.","link":"/datenschutz","theme":false};
+	</script>
+    <script type="text/javascript" src="https://www.lokalkompass.de/tmp/js/default-1823b67abe5988e7bcf758610f5b6eca.js"></script>
+    <script type="text/javascript" src="https://www.wvw-ora-anzeigenblaetter.de/permalink/e4d2a06a-cb4c-11e5-929d-005056a1001f.js"></script>
+    <script type="text/javascript" src="https://www.flowformore.de/lkplugins/lokalkompass.js"></script>
+
+    <script type="text/javascript"> var cockpitUrl = "https://statistics.gogol-publishing.de"; var cockpitTrackingEnabled = Boolean("1");</script><script src="https://www.lokalkompass.de/resources/javascript/cockpit/js.cockpit.js"></script>
+    <script src="https://www.lokalkompass.de/resources/javascript/tracking.js"></script>
+
+    <!-- No IVW-Head -->
+</head>
+
+<body>
+<div class="overlayWindow">
+    <div id="overlayWindowWrapper"></div>
+</div>
+<a id="feedback" href="https://www.lokalkompass.de/kontakt/" rel="nofollow"></a>
+<div class="adLeaderboardWrapper">
+    <div id="oms_superbanner" class="adLeaderboard">
+        <script type="text/javascript">
+				googletag.cmd.push(function() { googletag.display('oms_superbanner'); });
+			</script>
+    </div>
+</div>
+<div id="wrap">
+    <div id="header">
+        <div id="oms_skyscraper" class="adSkyscraper">
+            <script type="text/javascript">
+			googletag.cmd.push(function() { googletag.display('oms_skyscraper'); });
+		</script>
+        </div>
+        <div id="logo"><a href="https://www.lokalkompass.de/">&nbsp;</a></div>
+
+        <div style="position: absolute; top: 5px; left: 193px; height: 54px;">
+
+            <div class="left" id="userReportFrom">
+                <a href="https://www.lokalkompass.de/">Ihre Region</a><a href="https://www.lokalkompass.de/ort-waehlen/"><img src="https://www.lokalkompass.de/theme/resources/images/btnAendern.gif?20091210" alt="ändern" /></a>
+            </div>
+        </div>
+
+        <div id="navigationMeta">
+            <a class="metaMap" href="http://lokalkompass.de/karte">Karte</a>
+            <a class="metaTwitterBird" href="http://twitter.com/#!/lokalkompass_de" onclick="var w=window.open('http://twitter.com/#!/lokalkompass_de'); return false;">Folge uns</a>
+            <a class="metaFacebook" href="http://www.facebook.com/lokalkompass" onclick="var w=window.open('http://www.facebook.com/lokalkompass'); return false;">Fan werden</a>
+            <a href="https://www.lokalkompass.de/topgroups/">Gruppen</a>
+            <a href="https://www.lokalkompass.de/hilfe/">Hilfe</a>
+            <a href="https://www.lokalkompass.de/registrieren/">Registrieren</a>
+            <a class="arrowDownRight pointer" id="linkLogin" href="https://www.lokalkompass.de/login/">Anmelden</a>
+            <div class="spacerM"></div>
+            <a class="socialPluginsInfo right" style="margin-top: 3px;" href="https://www.lokalkompass.de/facebook-open-graph/" target="_blank" title="Informationen zu Facebook Open Graph"></a>
+            <a class="viralFacebookConnect right" href="https://www.facebook.com/v3.0/dialog/oauth?client_id=145822458957734&state=f4f2c6cae9e1be43857dd65550ea4f9a&response_type=code&sdk=php-sdk-5.6.2&redirect_uri=https%3A%2F%2Fwww.lokalkompass.de%2Ffacebook%2Faction%2Fm%2Flogin%2F&scope=public_profile%2Cemail" onclick="popUp('https://www.facebook.com/v3.0/dialog/oauth?client_id=145822458957734&state=f4f2c6cae9e1be43857dd65550ea4f9a&response_type=code&sdk=php-sdk-5.6.2&redirect_uri=https%3A%2F%2Fwww.lokalkompass.de%2Ffacebook%2Faction%2Fm%2Flogin%2F&scope=public_profile%2Cemail', 660, 600); return false;"></a>
+            <div class="clearright"></div>
+        </div>
+
+        <div id="boxLogin">
+            <form class="boxLoginForm" name="formLogin" method="post" action="https://www.lokalkompass.de/bilder/kirche.html">
+                <input type="hidden" name="foe" value="1" />
+                <input type="text" id="loginName" name="scmsession_data[login]" placeholder="E-Mail-Adresse" value="" />
+                <input type="password" id="loginPassword" name="scmsession_data[password]" placeholder="Passwort" value="" />
+                <a class="left" style="padding-top: 12px;" href="https://www.lokalkompass.de/register/resetpassword" rel="nofollow">Passwort vergessen?</a>
+                <button type="submit" name="scmsession_btn[login]" value="1">anmelden</button>
+                <div class="clearboth"></div>
+            </form>
+        </div>
+
+        <div id="navigationPrimary">
+            <ul>
+                <li class="active"><a title="Beiträge" href="https://www.lokalkompass.de/">Startseite</a></li>
+                <li><a title="Anzeigen" href="https://www.lokalkompass.de/anzeigen/">Anzeigen</a></li>
+                <li><a href="https://www.lokalkompass.de/beitrag-erstellen/">Beitrag erstellen</a></li>
+                <li><a href="https://www.lokalkompass.de/meine-seite/" rel="nofollow">Meine Seite</a></li>
+                <li><a href="https://www.lokalkompass.de/specials/">Specials</a></li>
+            </ul>
+            <div id="searchBar">
+                <!-- Google CSE -->
+                <form action="https://www.lokalkompass.de/suche/" id="cse-search-box" enctype="multipart/form-data; charset=UTF-8" accept-charset="UTF-8" method="get" name="Search">
+                    <input class="noborderright" type="text" name="q" id="q" autocomplete="off" /><button type="submit" name="sa" class="btnSmall" value="search">Suchen</button>
+                </form>
+                <!-- Ende Google CSE -->
+            </div>
+        </div>
+
+        <div id="navigationSecondary">
+            <ul>
+                <li><a title="Neueste Beiträge" href="https://www.lokalkompass.de/action/m/new/" >Neueste</a></li>
+                <li><a href="https://www.lokalkompass.de/themen/bildergalerie.html">Galerien</a></li>
+                <li><a title="Sport" href="https://www.lokalkompass.de/sport/" >Sport</a></li>
+                <li><a title="Kultur" href="https://www.lokalkompass.de/kultur/" >Kultur</a></li>
+                <li><a title="Politik" href="https://www.lokalkompass.de/politik/" >Politik</a></li>
+                <li><a title="Natur" href="https://www.lokalkompass.de/natur/" >Natur</a></li>
+                <li><a title="Ratgeber" href="https://www.lokalkompass.de/ratgeber/" >Ratgeber</a></li>
+                <li><a title="Leute" href="https://www.lokalkompass.de/leute/" >Leute</a></li>
+                <li><a title="Vereine" href="https://www.lokalkompass.de/vereine/" >Vereine</a></li>
+                <li><a title="Spaß" href="https://www.lokalkompass.de/spass/" >Spaß</a></li>
+                <li><a title="Termine" href="https://www.lokalkompass.de/veranstaltungen/" >Termine</a></li>
+                <li><a title="Termine" href="https://www.lokalkompass.de/marktplatz/" >Marktplatz</a></li>
+                <li><a href="https://www.lokalkompass.de/themen/reisekompass.html" onclick="var w=window.open('https://www.lokalkompass.de/themen/reisekompass.html', 'reisekompass'); return false;">Reise</a></li>
+            </ul>
+        </div>
+    </div>
+
+    <!--Breadcrumb_start-->
+    <div id="breadcrumbs" class="left" style="width: 700px;">
+        <div xmlns:v="http://rdf.data-vocabulary.org/#"><span typeof="v:Breadcrumb"><a href="https://www.lokalkompass.de/" rel="v:url" property="v:title">Ihre Region</a></span><a href="https://www.lokalkompass.de/themen/">Themen</a><a href="https://www.lokalkompass.de/themen/kirche.html">kirche</a>Bilder</div>    </div>
+
+    <div class="right" style="width: 260px; padding-top: 0px;">
+    </div>
+    <div class="clearboth"></div>
+    <!--Breadcrumb_end-->
+
+    <div id="oms_billboard" class="adBillboard marginBottomL">
+        <script type="text/javascript">
+			googletag.cmd.push(function() { googletag.display('oms_billboard'); });
+		</script>
+    </div>
+
+    <div>
+        <script type="text/javascript">wbox();</script>
+    </div>
+
+
+    <!-- Template Begin -->
+    <div id="content">
+        <div id="contentArea">
+
+            <h1 class="metaLikeL">Gut bewertete Bilder zum Thema kirche</h1>		<div class="spacerM"></div>
+
+            <div class="left" style="margin: 0 0 20px 0px; width: px; word-wrap: break-word;"><div class="mediadbgalleryfloat" style="margin: 0; float: none; display: block;">
+                <div style="width: 405px; height: 260px;" class="mediadbgallery relative">
+                    <span class="edge"></span>
+                    <div class="container">
+                        <div style="overflow: hidden; width: 405px; height: 260px; position: relative;"><a href="https://www.lokalkompass.de/bildergalerie/kirche-m3371115.html" class="pointer" title="...für einen wirklich gelungenen ABEND! Fritz, unser Buchdrucker ... danke, Dir und ALLEN Anderen für einen tollen Abend! LG aus dem Ruhrgebiet!" >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2016/02/19/3371115_web.jpg?1455922477" class="noborder" style="position: absolute; top: -22px; right: 0px; width: 405px; height: 304px; border: 0;" alt="...für einen wirklich gelungenen ABEND! Fritz, unser Buchdrucker ... danke, Dir und ALLEN Anderen für einen tollen Abend! LG aus dem Ruhrgebiet!" title="...für einen wirklich gelungenen ABEND! Fritz, unser Buchdrucker ... danke, Dir und ALLEN Anderen für einen tollen Abend! LG aus dem Ruhrgebiet!"  /></a></div></div>
+
+
+
+                    <span class="metaEdit"><span class="metaLike recent">28</span></span>	</div>
+            </div>
+
+            </div><div class="left" style="width: 220px;"><div class="left" style="margin: 0 0 20px 20px; width: px; word-wrap: break-word;"><div class="mediadbgalleryfloat" style="margin: 0; float: none; display: block;">
+            <div style="width: 200px; height: 120px;" class="mediadbgallery relative">
+                <span class="edge"></span>
+                <div class="container">
+                    <div style="overflow: hidden; width: 200px; height: 120px; position: relative;"><a href="https://www.lokalkompass.de/bildergalerie/kirche-m4252885.html" class="pointer" title="ertönten am 21.01.18 in der St. Vincentius-Kirche in Dinslaken aus dieser Konzertharfe Style 23 von Lyon & Healy, Chikago;" >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2018/01/22/4252885_web.jpg?1516611723" class="noborder" style="position: absolute; top: -102px; right: 0px; width: 200px; height: 323px; border: 0;" alt="ertönten am 21.01.18 in der St. Vincentius-Kirche in Dinslaken aus dieser Konzertharfe Style 23 von Lyon & Healy, Chikago;" title="ertönten am 21.01.18 in der St. Vincentius-Kirche in Dinslaken aus dieser Konzertharfe Style 23 von Lyon & Healy, Chikago;"  /></a></div></div>
+
+
+
+                <span class="metaEdit"><span class="metaLike recent">27</span></span>	</div>
+        </div>
+
+        </div><div class="left" style="margin: 0 0 20px 20px; width: px; word-wrap: break-word;"><div class="mediadbgalleryfloat" style="margin: 0; float: none; display: block;">
+            <div style="width: 200px; height: 120px;" class="mediadbgallery relative">
+                <span class="edge"></span>
+                <div class="container">
+                    <div style="overflow: hidden; width: 200px; height: 120px; position: relative;"><a href="https://www.lokalkompass.de/bildergalerie/kirche-m3089904.html" class="pointer" title="Mit einem lieben Gruss von Bruni" >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2015/08/09/3089904_preview.jpg?1439076602" class="noborder" style="position: absolute; top: -90px; right: 0px; width: 200px; height: 299px; border: 0;" alt="Mit einem lieben Gruss von Bruni" title="Mit einem lieben Gruss von Bruni"  /></a></div></div>
+
+
+
+                <span class="metaEdit"><span class="metaLike recent">25</span></span>	</div>
+        </div>
+
+        </div></div><div class="left" style="width: 220px;"><div class="left" style="margin: 0 0 20px 0px; width: px; word-wrap: break-word;"><div class="mediadbgalleryfloat" style="margin: 0; float: none; display: block;">
+            <div style="width: 200px; height: 120px;" class="mediadbgallery relative">
+                <span class="edge"></span>
+                <div class="container">
+                    <div style="overflow: hidden; width: 200px; height: 120px; position: relative;"><a href="https://www.lokalkompass.de/bildergalerie/kirche-m3737573.html" class="pointer" title="Kleiner Blick" >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2016/11/18/3737573_web.jpg?1479470435" class="noborder" style="position: absolute; top: -118px; right: 0px; width: 200px; height: 355px; border: 0;" alt="Kleiner Blick" title="Kleiner Blick"  /></a></div></div>
+
+
+
+                <span class="metaEdit"><span class="metaLike recent">22</span></span>	</div>
+        </div>
+
+        </div><div class="left" style="margin: 0 0 20px 0px; width: px; word-wrap: break-word;"><div class="mediadbgalleryfloat" style="margin: 0; float: none; display: block;">
+            <div style="width: 200px; height: 120px;" class="mediadbgallery relative">
+                <span class="edge"></span>
+                <div class="container">
+                    <div style="overflow: hidden; width: 200px; height: 120px; position: relative;"><a href="https://www.lokalkompass.de/bildergalerie/kirche-m3608147.html" class="pointer" title="Kirche Lippborg" >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2016/08/13/3608147_preview.jpg?1471118606" class="noborder" style="position: absolute; top: -7px; right: 0px; width: 200px; height: 133px; border: 0;" alt="Kirche Lippborg" title="Kirche Lippborg"  /></a></div></div>
+
+
+
+                <span class="metaEdit"><span class="metaLike recent">22</span></span>	</div>
+        </div>
+
+        </div></div><div class="left" style="margin: 0 0 20px 0px; width: px; word-wrap: break-word;"><div class="mediadbgalleryfloat" style="margin: 0; float: none; display: block;">
+            <div style="width: 405px; height: 260px;" class="mediadbgallery relative">
+                <span class="edge"></span>
+                <div class="container">
+                    <div style="overflow: hidden; width: 405px; height: 260px; position: relative;"><a href="https://www.lokalkompass.de/bildergalerie/kirche-m3722838.html" class="pointer" title="Viel erzählt es uns..." >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2016/11/06/3722838_web.jpg?1478425249" class="noborder" style="position: absolute; top: -22px; right: 0px; width: 405px; height: 304px; border: 0;" alt="Viel erzählt es uns..." title="Viel erzählt es uns..."  /></a></div></div>
+
+
+
+                <span class="metaEdit"><span class="metaLike recent">21</span></span>	</div>
+        </div>
+
+        </div><div class="left" style="margin: 0 0 20px 0px; width: px; word-wrap: break-word;"><div class="mediadbgalleryfloat" style="margin: 0; float: none; display: block;">
+            <div style="width: 405px; height: 260px;" class="mediadbgallery relative">
+                <span class="edge"></span>
+                <div class="container">
+                    <div style="overflow: hidden; width: 405px; height: 260px; position: relative;"><a href="https://www.lokalkompass.de/bildergalerie/kirche-m3371138.html" class="pointer" title="...ein Nachtwächter, ein "BUCH-Druck-Gutenberg-Jünger", tolle LK´ler und lecker Essen + Trinken ... ein einfach GLÜCK mit dem Wetter ... in Neukirchen-Vluyn, mit FRITZE und CO.  MERCI ... und GUTE NACHT!" >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2016/02/20/3371138_web.jpg?1455924004" class="noborder" style="position: absolute; top: -140px; right: 0px; width: 405px; height: 540px; border: 0;" alt="...ein Nachtwächter, ein 'BUCH-Druck-Gutenberg-Jünger', tolle LK´ler und lecker Essen + Trinken ... ein einfach GLÜCK mit dem Wetter ... in Neukirchen-Vluyn, mit FRITZE und CO.  MERCI ... und GUTE NACHT!" title="...ein Nachtwächter, ein 'BUCH-Druck-Gutenberg-Jünger', tolle LK´ler und lecker Essen + Trinken ... ein einfach GLÜCK mit dem Wetter ... in Neukirchen-Vluyn, mit FRITZE und CO.  MERCI ... und GUTE NACHT!"  /></a></div></div>
+
+
+
+                <span class="metaEdit"><span class="metaLike recent">21</span></span>	</div>
+        </div>
+
+        </div><div class="left" style="width: 220px;"><div class="left" style="margin: 0 0 20px 20px; width: px; word-wrap: break-word;"><div class="mediadbgalleryfloat" style="margin: 0; float: none; display: block;">
+            <div style="width: 200px; height: 120px;" class="mediadbgallery relative">
+                <span class="edge"></span>
+                <div class="container">
+                    <div style="overflow: hidden; width: 200px; height: 120px; position: relative;"><a href="https://www.lokalkompass.de/bildergalerie/kirche-m4247987.html" class="pointer" title="...die TAGE mal´ in Essen-ALTENESSEN gewesen, in der "ALTEN Kirche" dort...! In dieser "Kulturkirche" finden viele verschiedene TOLLE Dinge statt... die TAGE spielte AEHAM AHMAD dort... ein syrischer Flüchtling, DER "Trümmer-Pianist".... interessant ...!" >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2018/01/17/4247987_preview.jpg?1516222301" class="noborder" style="position: absolute; top: -15px; right: 0px; width: 200px; height: 150px; border: 0;" alt="...die TAGE mal´ in Essen-ALTENESSEN gewesen, in der 'ALTEN Kirche' dort...! In dieser 'Kulturkirche' finden viele verschiedene TOLLE Dinge statt... die TAGE spielte AEHAM AHMAD dort... ein syrischer Flüchtling, DER 'Trümmer-Pianist'.... interessant ...!" title="...die TAGE mal´ in Essen-ALTENESSEN gewesen, in der 'ALTEN Kirche' dort...! In dieser 'Kulturkirche' finden viele verschiedene TOLLE Dinge statt... die TAGE spielte AEHAM AHMAD dort... ein syrischer Flüchtling, DER 'Trümmer-Pianist'.... interessant ...!"  /></a></div></div>
+
+
+
+                <span class="metaEdit"><span class="metaLike recent">20</span></span>	</div>
+        </div>
+
+        </div><div class="left" style="margin: 0 0 20px 20px; width: px; word-wrap: break-word;"><div class="mediadbgalleryfloat" style="margin: 0; float: none; display: block;">
+            <div style="width: 200px; height: 120px;" class="mediadbgallery relative">
+                <span class="edge"></span>
+                <div class="container">
+                    <div style="overflow: hidden; width: 200px; height: 120px; position: relative;"><a href="https://www.lokalkompass.de/bildergalerie/kirche-m2225670.html" class="pointer" title="Die Kirche in Emmerich-Hoch Elten. Die beiden Steelen markieren eine Sichtachse. Im Rücken kann man bis Kleve schauen." >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2014/03/22/2225670_preview.jpg?1395506696" class="noborder" style="position: absolute; top: -74px; right: 0px; width: 200px; height: 267px; border: 0;" alt="Die Kirche in Emmerich-Hoch Elten. Die beiden Steelen markieren eine Sichtachse. Im Rücken kann man bis Kleve schauen." title="Die Kirche in Emmerich-Hoch Elten. Die beiden Steelen markieren eine Sichtachse. Im Rücken kann man bis Kleve schauen."  /></a></div></div>
+
+
+
+                <span class="metaEdit"><span class="metaLike recent">20</span></span>	</div>
+        </div>
+
+        </div></div><div class="left" style="width: 220px;"><div class="left" style="margin: 0 0 20px 0px; width: px; word-wrap: break-word;"><div class="mediadbgalleryfloat" style="margin: 0; float: none; display: block;">
+            <div style="width: 200px; height: 120px;" class="mediadbgallery relative">
+                <span class="edge"></span>
+                <div class="container">
+                    <div style="overflow: hidden; width: 200px; height: 120px; position: relative;"><a href="https://www.lokalkompass.de/bildergalerie/kirche-m3732275.html" class="pointer" title="Fühle ich hier innere Ruhe." >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2016/11/13/3732275_preview.jpg?1479052420" class="noborder" style="position: absolute; top: -15px; right: 0px; width: 200px; height: 150px; border: 0;" alt="Fühle ich hier innere Ruhe." title="Fühle ich hier innere Ruhe."  /></a></div></div>
+
+
+
+                <span class="metaEdit"><span class="metaLike recent">19</span></span>	</div>
+        </div>
+
+        </div><div class="left" style="margin: 0 0 20px 0px; width: px; word-wrap: break-word;"><div class="mediadbgalleryfloat" style="margin: 0; float: none; display: block;">
+            <div style="width: 200px; height: 120px;" class="mediadbgallery relative">
+                <span class="edge"></span>
+                <div class="container">
+                    <div style="overflow: hidden; width: 200px; height: 120px; position: relative;"><a href="https://www.lokalkompass.de/bildergalerie/kirche-m4068965.html" class="pointer" title="Die Kugel zeigt es uns... es ist die Basilika St. Margareta in Düsseldorf-Gerresheim!" >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2017/08/13/4068965_preview.jpg?1502654426" class="noborder" style="position: absolute; top: -38px; right: 0px; width: 200px; height: 196px; border: 0;" alt="Die Kugel zeigt es uns... es ist die Basilika St. Margareta in Düsseldorf-Gerresheim!" title="Die Kugel zeigt es uns... es ist die Basilika St. Margareta in Düsseldorf-Gerresheim!"  /></a></div></div>
+
+
+
+                <span class="metaEdit"><span class="metaLike recent">18</span></span>	</div>
+        </div>
+
+        </div></div><div class="left" style="margin: 0 0 20px 0px; width: px; word-wrap: break-word;"><div class="mediadbgalleryfloat" style="margin: 0; float: none; display: block;">
+            <div style="width: 405px; height: 260px;" class="mediadbgallery relative">
+                <span class="edge"></span>
+                <div class="container">
+                    <div style="overflow: hidden; width: 405px; height: 260px; position: relative;"><a href="https://www.lokalkompass.de/bildergalerie/kirche-m3084457.html" class="pointer" title="Margaretenkirche Methler" >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2015/08/05/3084457_web.jpg?1438796721" class="noborder" style="position: absolute; top: -5px; right: 0px; width: 405px; height: 270px; border: 0;" alt="Margaretenkirche Methler" title="Margaretenkirche Methler"  /></a></div></div>
+
+
+
+                <span class="metaEdit"><span class="metaLike recent">18</span></span>	</div>
+        </div>
+
+        </div><div class="clearleft"></div>
+            <div class="spacerM"></div><div class="pagination"><div class="pageContainer"><button class="lowprofile" disabled="disabled" onclick="return false;"><i class="fa fa-lg fa-chevron-left"></i></button><span class="pages"><a class="active" href="https://www.lokalkompass.de/bilder/kirche.html#paginaTop">1</a><a href="https://www.lokalkompass.de/bilder/kirche.html/action/page/2/#paginaTop">2</a><a href="https://www.lokalkompass.de/bilder/kirche.html/action/page/3/#paginaTop">3</a><a href="https://www.lokalkompass.de/bilder/kirche.html/action/page/4/#paginaTop">4</a><a href="https://www.lokalkompass.de/bilder/kirche.html/action/page/5/#paginaTop">5</a><span>...</span><a href="https://www.lokalkompass.de/bilder/kirche.html/action/page/47/#paginaTop">47</a></span><button class="lowprofile" onclick="window.location = 'https://www.lokalkompass.de/bilder/kirche.html/action/page/2/#paginaTop';"><i class="fa fa-lg fa-chevron-right"></i></button></div></div>	</div>
+
+        <div id="sidebar">
+            <div class="teaserBox ">
+                <div class="h3 teaser h3_teaser"><span>Bilder zu kirche von:</span></div>
+                <div class="clearboth"></div>
+                <div class="userTeaser">
+                    <div class="mediadbgalleryfloat" style="margin: 2px 5px 0 0;">
+                        <div style="width: 42px; height: 42px;" class="mediadbgallery relative">
+                            <span class="edge"></span>
+                            <div class="container">
+                                <div style="overflow: hidden; width: 42px; height: 42px; position: relative;"><a href="https://www.lokalkompass.de/duesseldorf/profile/margot-kluetsch-61807.html" class="pointer" >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2018/02/28/4311363_icon.jpg?1519831618" class="noborder" style="position: absolute; top: -7px; right: 0px; width: 42px; height: 56px; border: 0;" alt="Margot Klütsch" title="Margot Klütsch"  /></a></div></div>
+
+
+
+                        </div>
+                    </div>
+
+                    <a href="https://www.lokalkompass.de/duesseldorf/profile/margot-kluetsch-61807.html">Margot Klütsch</a>
+                    <br />
+                    <span class="metaLike"></span>233 Bilder        <span class="recent"></span>
+                    <div class="clearboth"></div>
+                </div><div class="userTeaser">
+                <div class="mediadbgalleryfloat" style="margin: 2px 5px 0 0;">
+                    <div style="width: 42px; height: 42px;" class="mediadbgallery relative">
+                        <span class="edge"></span>
+                        <div class="container">
+                            <div style="overflow: hidden; width: 42px; height: 42px; position: relative;"><a href="https://www.lokalkompass.de/schermbeck/profile/elisabeth-jagusch-42530.html" class="pointer" >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2016/04/27/3453865_icon.jpg?1461751949" class="noborder" style="position: absolute; top: -4px; right: 0px; width: 42px; height: 49px; border: 0;" alt="Elisabeth Jagusch" title="Elisabeth Jagusch"  /></a></div></div>
+
+
+
+                    </div>
+                </div>
+
+                <a href="https://www.lokalkompass.de/schermbeck/profile/elisabeth-jagusch-42530.html">Elisabeth Jagusch</a>
+                <br />
+                <span class="metaLike"></span>36 Bilder        <span class="recent"></span>
+                <div class="clearboth"></div>
+            </div><div class="userTeaser">
+                <div class="mediadbgalleryfloat" style="margin: 2px 5px 0 0;">
+                    <div style="width: 42px; height: 42px;" class="mediadbgallery relative">
+                        <span class="edge"></span>
+                        <div class="container">
+                            <div style="overflow: hidden; width: 42px; height: 42px; position: relative;"><a href="https://www.lokalkompass.de/bochum/profile/gudrun-wirbitzky-29748.html" class="pointer" >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2018/05/01/4495935_icon.jpg?1525199904" class="noborder" style="position: absolute; top: -9px; right: 0px; width: 42px; height: 60px; border: 0;" alt="Gudrun Wirbitzky" title="Gudrun Wirbitzky"  /></a></div></div>
+
+
+
+                    </div>
+                </div>
+
+                <a href="https://www.lokalkompass.de/bochum/profile/gudrun-wirbitzky-29748.html">Gudrun Wirbitzky</a>
+                <br />
+                <span class="metaLike"></span>35 Bilder        <span class="recent"></span>
+                <div class="clearboth"></div>
+            </div><div class="userTeaser">
+                <div class="mediadbgalleryfloat" style="margin: 2px 5px 0 0;">
+                    <div style="width: 42px; height: 42px;" class="mediadbgallery relative">
+                        <span class="edge"></span>
+                        <div class="container">
+                            <div style="overflow: hidden; width: 42px; height: 42px; position: relative;"><a href="https://www.lokalkompass.de/duesseldorf/profile/bruni-rentzing-25980.html" class="pointer" >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2018/03/14/4329566_icon.jpg?1521050080" class="noborder" style="position: absolute; top: 0px; right: -14px; width: 56px; height: 42px; border: 0;" alt="Bruni Rentzing" title="Bruni Rentzing"  /></a></div></div>
+
+
+
+                    </div>
+                </div>
+
+                <a href="https://www.lokalkompass.de/duesseldorf/profile/bruni-rentzing-25980.html">Bruni Rentzing</a>
+                <br />
+                <span class="metaLike"></span>24 Bilder        <span class="recent"></span>
+                <div class="clearboth"></div>
+            </div><div class="userTeaser">
+                <div class="mediadbgalleryfloat" style="margin: 2px 5px 0 0;">
+                    <div style="width: 42px; height: 42px;" class="mediadbgallery relative">
+                        <span class="edge"></span>
+                        <div class="container">
+                            <div style="overflow: hidden; width: 42px; height: 42px; position: relative;"><a href="https://www.lokalkompass.de/menden/profile/peter-gerber-111.html" class="pointer" >			<img src="https://d1mquhhbkq1b1r.cloudfront.net/2016/10/12/3694668_icon.jpg?1476280620" class="noborder" style="position: absolute; top: 0px; right: 0px; width: 42px; height: 42px; border: 0;" alt="Peter Gerber" title="Peter Gerber"  /></a></div></div>
+
+
+
+                    </div>
+                </div>
+
+                <a href="https://www.lokalkompass.de/menden/profile/peter-gerber-111.html">Peter Gerber</a>
+                <br />
+                <span class="metaLike"></span>21 Bilder        <span class="recent"></span>
+                <div class="clearboth"></div>
+            </div>und 75 weiteren B&uuml;rgerreportern<br /></div><div class="teaserBox">
+            <div class="box coverage">
+                <span class="bold participate">Diese Seite weiterempfehlen:</span><div class="spacerS"></div>		<ul class="socialBar">
+                <li><a class="facebook-bg" title="Beitrag auf Facebook teilen" href="https://www.facebook.com/sharer/sharer.php?u=https://www.lokalkompass.de/bilder/kirche.html&t=Auf lokalkompass.de gelesen:" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600');return false;" rel="nofollow"><i class="fa fa-fw fa-lg fa-facebook-official"></i>Teilen</a></li><li><a class="twitter-bg" title="Beitrag auf Twitter weiterempfehlen" href="https://twitter.com/intent/tweet?url=https://www.lokalkompass.de/bilder/kirche.html&text=Bilder+kirche%3A+554+gut+bewertete+Fotos+der+Lokalkompass+B%C3%BCrgerreporter&via=lokalkompass_de" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600');return false;" rel="nofollow"><i class="fa fa-fw fa-lg fa-twitter"></i>Twittern</a></li><li><a class="googleplus-bg" title="Beitrag auf Google+ weiterempfehlen" href="https://plus.google.com/share?url=https://www.lokalkompass.de/bilder/kirche.html" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600');return false;" rel="nofollow"><i class="fa fa-fw fa-lg fa-google-plus"></i>Teilen</a></li>		</ul>
+                <div class="clearboth"></div>
+            </div>
+        </div>
+        </div>
+        <div class="clearboth"></div>
+    </div>    <!-- Template End -->
+
+    <div id="footer">
+        <div class="linkbox">
+            <div class="label">Unternehmen</div>
+            <span class="link" onclick="var w = window.open('http://www.wvw-ora-anzeigenblaetter.de/unternehmen/aktuelles/', 'wvwpopup');">Was gibts Neues</span><div class="spacerVertical">|</div>
+            <span class="link" onclick="var w = window.open('http://www.wvw-ora-anzeigenblaetter.de/jobs-karriere/arbeiten-mit-uns/', 'wvwpopup');">Jobs & Karriere</span>
+
+            <div class="separator"></div>
+            <div class="label">Informationen</div>
+            <span class="link" onclick="window.location.href = 'https://www.lokalkompass.de/hilfe/';">Hilfe</span><div class="spacerVertical">|</div>
+            <span class="link" onclick="window.location.href = 'https://www.lokalkompass.de/verhaltenskodex/';">Verhaltenskodex</span><div class="spacerVertical">|</div>
+            <span class="link" onclick="window.location.href = 'https://www.lokalkompass.de/datenschutz/';">Datenschutz</span><div class="spacerVertical">|</div>
+            <span class="link" onclick="window.location.href = 'https://www.lokalkompass.de/agb/';">AGB</span><div class="spacerVertical">|</div>
+            <span class="link" onclick="window.location.href = 'https://www.lokalkompass.de/impressum/';">Impressum</span>
+
+            <div class="separator"></div>
+            <div class="label">Kontakt</div>
+            <span class="link" onclick="var w = window.open('http://www.wvw-ora-anzeigenblaetter.de/unternehmen/geschaeftsstellen/', 'wvwpopup');">Anschriften</span>
+
+            <div class="separator"></div>
+            <div class="label">Dienste</div>
+            <span class="link" onclick="jQuery.cookie('responsive', 1, { path: '/' }); jQuery.cookie('responsive-everywhere', 1, { path: '/' }); window.location.href = 'https://www.lokalkompass.de/bilder/kirche.html';">Mobile Webseite</span>
+        </div>
+
+        <div class="separator"></div>
+        <div class="spacerXXL"></div>
+        <div class="small">
+            Powered by Gogol Publishing 2002-2018 – Dieses Onlineportal mit dem integrierten <a rel="nofollow" href="http://www.gogol-publishing.de/informationen-zum-unternehmen-gogol-medien/leserreporter/">Leserreporter-Modul</a> wird mit Gogol Publishing produziert - dem einfachen Redaktionssystem für Anzeigenblätter und Lokalzeitungen.        </div>
+        <a class="arrowUpDouble right participate" href="#header">Zum Seitenanfang</a>
+    </div>
+</div>
+<div id="oms_ist">
+    <script type="text/javascript">
+			googletag.cmd.push(function() { googletag.display('oms_ist'); });
+		</script>
+</div>
+<script type="text/javascript" src="https://www.lokalkompass.de/tmp/js/default-603796eceb38b89efa08764ed237d85b.js"></script>
+
+<script type="text/javascript">
+sitecomplete();
+</script>
+<!-- Google Analytics Opt-out -->
+<script type="text/javascript">
+		if (jQuery.cookie('ga-opt-out') === '1') {
+			window['ga-disable-UA-38121643-1'] = true;
+			window['ga-disable-UA-38121643-2'] = true;
+		}
+
+		jQuery(function() {
+			jQuery('[data-ga-optout-enable]').on('click', function() {
+				jQuery.cookie('ga-opt-out', '1', { expires: 365, path: '/' });
+			});
+
+			jQuery('[data-ga-optout-disable]').on('click', function() {
+				jQuery.cookie('ga-opt-out', '0', { expires: 365, path: '/' });
+			});
+		});
+	</script>
+<!-- Google Analytics Opt-out Ende -->
+
+<!-- Google Analytics -->
+<script type="text/javascript">
+	var _gaq = _gaq || [];
+	_gaq.push(['_setAccount', 'UA-38121643-1']);
+	_gaq.push(['_setDomainName', 'lokalkompass.de']);
+			_gaq.push(['_setCustomVar', 1, 'UserType', '0', 2]);
+			_gaq.push (['_gat._anonymizeIp']);
+	_gaq.push(['_trackPageview']);
+	(function() {
+		var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+		ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+		var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+	})();
+
+	</script>
+<!-- Google Analytics Ende -->
+
+<!-- Google Analytics Universal -->
+<script type="text/javascript">
+		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+		})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+		ga('create', 'UA-38121643-2', 'auto');
+		ga('set', 'anonymizeIp', true);
+
+				ga('set', 'dimension1', 'Visitor');
+				ga('set', 'dimension2', 'Sonstige');
+				ga('send', 'pageview');
+	</script>
+<!-- End Google Analytics Universal -->
+<!-- No IVW-Body -->
+
+
+
+
+</body>
+</html>


### PR DESCRIPTION
I disallowed duplicate attribute keys in html to avoid `org.xml.sax.SAXParseException`s.

Along the way, I also cleaned up some annoying or unnecessary logging/console output produced by our massive suite of test cases.

Also cleaned up some javadoc/miscellaneous items.

mvn clean test -> all tests passed