### PR TITLE
ANY23-385 improve encoding detection

### DIFF
--- a/encoding/src/test/java/org/apache/any23/encoding/TikaEncodingDetectorTest.java
+++ b/encoding/src/test/java/org/apache/any23/encoding/TikaEncodingDetectorTest.java
@@ -22,8 +22,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Test case for {@link TikaEncodingDetector}.
@@ -74,6 +77,20 @@ public class TikaEncodingDetectorTest {
     @Test
     public void testEncodingHTML() throws IOException {
          assertEncoding( "UTF-8", "/html/encoding-test.html" );
+    }
+
+    @Test
+    public void testXMLEncodingPattern() throws IOException {
+        String[] strings = {
+                "<?xml encoding=\"UTF-8\"?>",
+                " \n<?xMl encoding   = 'utf-8'?>",
+                "\n <?Xml enCoding=Utf8?>"
+        };
+        for (String s : strings) {
+            byte[] bytes = s.getBytes(StandardCharsets.US_ASCII);
+            Charset detected = TikaEncodingDetector.detectXmlEncoding(new ByteArrayInputStream(bytes), 256);
+            Assert.assertEquals(detected, StandardCharsets.UTF_8);
+        }
     }
 
     private void assertEncoding(final String expected, final String resource) throws IOException {


### PR DESCRIPTION
1. Increase default sniff limit for text charset detection from 12000 bytes to 65536 bytes
2. Include results of xml declaration encoding detection
3. Include results of html meta charset encoding detection

mvn clean test -> all tests passed