### PR TITLE
ANY23-388 Make field writer and constructor protected

### DIFF
--- a/core/src/main/java/org/apache/any23/writer/RDFWriterTripleHandler.java
+++ b/core/src/main/java/org/apache/any23/writer/RDFWriterTripleHandler.java
@@ -35,7 +35,7 @@ import org.eclipse.rdf4j.rio.RDFWriter;
  */
 public abstract class RDFWriterTripleHandler implements FormatWriter, TripleHandler {
 
-    private final RDFWriter writer;
+    protected final RDFWriter writer;
 
     private boolean closed = false;
 
@@ -44,7 +44,7 @@ public abstract class RDFWriterTripleHandler implements FormatWriter, TripleHand
      */
     private boolean annotated = false;
 
-    RDFWriterTripleHandler(RDFWriter destination) {
+    protected RDFWriterTripleHandler(RDFWriter destination) {
         writer = destination;
         try {
             writer.startRDF();


### PR DESCRIPTION
Make the constructor of `RDFWriterTripleHandler` and its field `writer` protected, as [discussed](https://issues.apache.org/jira/browse/ANY23-388?focusedCommentId=16580679&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16580679) by me, @lewismc and @HansBrende. This replaces PR #116