### PR TITLE
ANY23-392: Add configuration for maven-jetty-plugin

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -137,6 +137,9 @@
         <version>${jetty.runner.version}</version>
         <configuration>
           <webAppConfig>
+              <baseResource implementation="org.eclipse.jetty.util.resource.ResourceCollection">
+                  <resourcesAsCSV>src/main</resourcesAsCSV>
+              </baseResource>
             <contextPath>/${project.artifactId}</contextPath>
           </webAppConfig>
         </configuration>


### PR DESCRIPTION
Add configuration to load src/main/resources.
Plugin settings are useful only for debugging purposes.

* loads content of `src/main/` into web application resources