### PR TITLE
ANY23-67 test against online microdata test-suite

### DIFF
--- a/core/src/test/java/org/apache/any23/extractor/microdata/MicrodataExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/microdata/MicrodataExtractorTest.java
@@ -18,7 +18,8 @@
 package org.apache.any23.extractor.microdata;
 
 import org.apache.any23.Any23;
-import org.apache.any23.extractor.ExtractionContext;
+import org.apache.any23.configuration.DefaultConfiguration;
+import org.apache.any23.configuration.ModifiableConfiguration;
 import org.apache.any23.extractor.ExtractionException;
 import org.apache.any23.extractor.ExtractorFactory;
 import org.apache.any23.extractor.IssueReport;
@@ -132,7 +133,9 @@ public class MicrodataExtractorTest extends AbstractExtractorTestCase {
         final IRI resultPred = RDFUtils.iri("http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result");
         final IRI namePred = RDFUtils.iri("http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name");
 
-        Any23 microdataRunner = new Any23(MicrodataExtractorFactory.NAME);
+        ModifiableConfiguration config = DefaultConfiguration.copy();
+        config.setProperty("any23.microdata.strict", DefaultConfiguration.FLAG_PROPERTY_ON);
+        Any23 microdataRunner = new Any23(config, MicrodataExtractorFactory.NAME);
         microdataRunner.setHTTPUserAgent("apache-any23-test-user-agent");
         ArrayList<String> passedTests = new ArrayList<>();
         TreeMap<String, String> failedTests = new TreeMap<>();

--- a/core/src/test/java/org/apache/any23/extractor/microdata/MicrodataExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/microdata/MicrodataExtractorTest.java
@@ -28,7 +28,7 @@ import org.apache.any23.rdf.RDFUtils;
 import org.apache.any23.source.DocumentSource;
 import org.apache.any23.source.HTTPDocumentSource;
 import org.apache.any23.vocab.SINDICE;
-import org.apache.any23.writer.TripleHandler;
+import org.apache.any23.writer.TripleWriterHandler;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.Literal;
@@ -121,16 +121,11 @@ public class MicrodataExtractorTest extends AbstractExtractorTestCase {
         DocumentSource source = new HTTPDocumentSource(ttlRunner.getHTTPClient(),
                 "http://w3c.github.io/microdata-rdf/tests/manifest.ttl");
         HashMap<Resource, HashMap<IRI, ArrayDeque<Value>>> map = new HashMap<>(256);
-        ttlRunner.extract(source, new TripleHandler() {
-            public void startDocument(IRI documentIRI) {}
-            public void openContext(ExtractionContext context) { }
-            public void receiveTriple(Resource s, IRI p, Value o, IRI g, ExtractionContext context) {
+        ttlRunner.extract(source, new TripleWriterHandler() {
+            public void writeTriple(Resource s, IRI p, Value o, Resource g) {
                 map.computeIfAbsent(s, k -> new HashMap<>()).computeIfAbsent(p, k -> new ArrayDeque<>()).add(o);
             }
-            public void receiveNamespace(String prefix, String uri, ExtractionContext context) { }
-            public void closeContext(ExtractionContext context) {}
-            public void endDocument(IRI documentIRI) { }
-            public void setContentLength(long contentLength) { }
+            public void writeNamespace(String prefix, String uri) { }
             public void close() { }
         });
         final IRI actionPred = RDFUtils.iri("http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action");
@@ -165,31 +160,21 @@ public class MicrodataExtractorTest extends AbstractExtractorTestCase {
             String name = ((Literal)item.get(namePred).pop()).getLabel()
                     + ": " + ((Literal)item.get(RDFS.COMMENT).pop()).getLabel();
             TreeModel actual = new TreeModel();
-            microdataRunner.extract(new HTTPDocumentSource(microdataRunner.getHTTPClient(), action.stringValue()), new TripleHandler() {
-                public void startDocument(IRI documentIRI) {}
-                public void openContext(ExtractionContext context) { }
-                public void receiveTriple(Resource s, IRI p, Value o, IRI g, ExtractionContext context) {
+            microdataRunner.extract(new HTTPDocumentSource(microdataRunner.getHTTPClient(), action.stringValue()), new TripleWriterHandler() {
+                public void writeTriple(Resource s, IRI p, Value o, Resource g) {
                     actual.add(s, p, o);
                 }
-                public void receiveNamespace(String prefix, String uri, ExtractionContext context) { }
-                public void closeContext(ExtractionContext context) { }
-                public void endDocument(IRI documentIRI) { }
-                public void setContentLength(long contentLength) { }
+                public void writeNamespace(String prefix, String uri) { }
                 public void close() { }
             });
 
             TreeModel expected = new TreeModel();
             if (result != null) {
-                ttlRunner.extract(new HTTPDocumentSource(ttlRunner.getHTTPClient(), result.stringValue()), new TripleHandler() {
-                    public void startDocument(IRI documentIRI) {}
-                    public void openContext(ExtractionContext context) { }
-                    public void receiveTriple(Resource s, IRI p, Value o, IRI g, ExtractionContext context) {
+                ttlRunner.extract(new HTTPDocumentSource(ttlRunner.getHTTPClient(), result.stringValue()), new TripleWriterHandler() {
+                    public void writeTriple(Resource s, IRI p, Value o, Resource g) {
                         expected.add(s, p, o);
                     }
-                    public void receiveNamespace(String prefix, String uri, ExtractionContext context) { }
-                    public void closeContext(ExtractionContext context) {}
-                    public void endDocument(IRI documentIRI) { }
-                    public void setContentLength(long contentLength) { }
+                    public void writeNamespace(String prefix, String uri) { }
                     public void close() { }
                 });
             }


### PR DESCRIPTION
I created a microdata unit test which tests against the latest online [microdata test suite](http://w3c.github.io/microdata-rdf/tests/).

Currently, 30 out of 84 total tests are failing!

*Note: the tests are relaxed such that the expected model is only required to be a subset of the actual model, and not necessarily the other way around. Requiring strict isomorphism, on the other hand, causes 83 out of 84 tests to fail.*

**The 30 failing tests are as follows:**
Test 0002: Item with no itemtype and 2 elements with equivalent itemprop
Test 0003: Item with itemprop having two properties
Test 0046: Use of time with `@datetime` xsd:time
Test 0047: Use of time with `@datetime` xsd:dateTime
Test 0048: Use of time with `@datetime` xsd:duration
Test 0049: Use of time with `@datetime` invalid
Test 0051: relative URL as itemid
Test 0052: token property no `@itemtype`
Test 0053: token property empty `@itemtype`
Test 0054: token property and relative `@itemtype`
Test 0056: token property and multiple `@itemtypes` from different vocabularies
Test 0062: `@itemref` to single id
Test 0063: `@itemref` generates property values
Test 0064: `@itemref` to single id with different types
Test 0065: `@itemref` to multiple ids
Test 0066: `@itemref` with chaining
Test 0067: Shared `@itemref`
Test 0070: Property URI generation (default) 3
Test 0071: Vocabulary Expansion test with schema:additionalType
Test 0073: Vocabulary Expansion test with rdfs:subPropertyOf
Test 0074: Vocabulary Expansion test with owl:equivalentProperty
Test 0075: Use of data and xsd:float
Test 0076: Use of data and xsd:integer
Test 0077: Use of data and string
Test 0078: Use of meter and xsd:double
Test 0079: Use of meter and xsd:integer
Test 0080: Use of meter and xsd:string
Test 0081: Simple `@itemprop-reverse` (experimental)
Test 0082: `@itemprop-reverse` with `@itemscope` value (experimental)
Test 0084: `@itemprop-reverse` with `@itemprop` (experimental)

For more details on expected vs. actual statements, run the `MicrodataExtractorTest.runOnlineTests()` test.