### PR TITLE
ANY23-418 improve TikaEncodingDetector

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -22,3 +22,6 @@ Michael Schmitz, (Developers) Open IE 4 Software
 US patent number 7,877,343 and 12/970,155 patent pending
 (https://github.com/allenai/openie-standalone) under the Open IE 4 
 Software License Agreement
+
+This product includes software developed by Hans Brende
+(https://github.com/HansBrende/f8) under an MIT license.

--- a/encoding/pom.xml
+++ b/encoding/pom.xml
@@ -47,6 +47,12 @@
     </dependency>
     <!-- END: Any23 -->
 
+    <dependency>
+      <groupId>org.rypt</groupId>
+      <artifactId>f8</artifactId>
+      <version>1.0</version>
+    </dependency>
+
     <!-- BEGIN: Tika -->
     <dependency>
       <groupId>org.apache.tika</groupId>

--- a/encoding/pom.xml
+++ b/encoding/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>org.rypt</groupId>
       <artifactId>f8</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
     </dependency>
 
     <!-- BEGIN: Tika -->

--- a/encoding/src/main/java/org/apache/any23/encoding/EncodingUtils.java
+++ b/encoding/src/main/java/org/apache/any23/encoding/EncodingUtils.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.any23.encoding;
+
+import org.apache.tika.utils.CharsetUtils;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Evaluator;
+import org.jsoup.select.QueryParser;
+import org.jsoup.select.Selector;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Hans Brende
+ */
+class EncodingUtils {
+
+    /**
+     * Very efficient method to convert an input stream directly to an ISO-8859-1 encoded string
+     */
+    static String iso_8859_1(InputStream is) throws IOException {
+        StringBuilder chars = new StringBuilder(Math.max(is.available(), 8192));
+        byte[] buffer = new byte[8192];
+        int n;
+        while ((n = is.read(buffer)) != -1) {
+            chars.ensureCapacity(chars.length() + n);
+            for (int i = 0; i < n; i++) {
+                chars.append((char)(buffer[i] & 0xFF));
+            }
+        }
+        return chars.toString();
+    }
+
+
+    /**
+     * Returns null for an ASCII stream, true for a UTF-8 stream,
+     * and false for a stream encoded in something other than UTF-8.
+     */
+    static Boolean isUTF8(InputStream stream) throws IOException {
+        long numInvalid = 0;
+        long numValid = 0;
+
+        int state = 0;
+
+        int i;
+        while ((i = stream.read()) != -1) {
+            state = nextStateUtf8(state, (byte)i);
+            if (state == -1) { //bad state
+                numInvalid++;
+            } else if (state >= 0) { //state is a valid codepoint
+                //take a hint from jchardet: count SO, SI, ESC as invalid
+                if (state == 0x0E || state == 0x0F || state == 0x1B) {
+                    numInvalid++;
+                } else if (state > 0x7F) { //was at least a two-byte sequence
+                    numValid++;
+
+                    //shortcut: avoid reading entire stream
+                    //if we can detect early on that it's UTF-8
+                    if (numValid > (numInvalid + 1) * 10) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        if (numValid == 0 && numInvalid == 0) { //Plain ASCII
+            return null;
+        }
+        //condition for success based roughly on ICU4j's CharsetRecog_UTF8 class
+        //valid multi-byte UTF-8 sequences are unlikely to occur by chance
+        return numValid > numInvalid * 10;
+    }
+
+
+    /**
+     * Returns the next UTF-8 state given the next byte of input and the current state.
+     * If the input byte is the last byte in a valid UTF-8 byte sequence,
+     * the returned state will be the corresponding unicode character (in the range of 0 through 0x10FFFF).
+     * Otherwise, a negative integer is returned. A state of -1 is returned whenever an
+     * invalid UTF-8 byte sequence is detected.
+     */
+    static int nextStateUtf8(int currentState, byte nextByte) {
+        switch (currentState & 0xF0000000) {
+            case 0:
+                if ((nextByte & 0x80) == 0) { //0 trailing bytes (ASCII)
+                    return nextByte;
+                } else if ((nextByte & 0xE0) == 0xC0) { //1 trailing byte
+                    if (nextByte == (byte) 0xC0 || nextByte == (byte) 0xC1) { //0xCO & 0xC1 are overlong
+                        return -1;
+                    } else {
+                        return nextByte & 0xC000001F;
+                    }
+                } else if ((nextByte & 0xF0) == 0xE0) { //2 trailing bytes
+                    if (nextByte == (byte) 0xE0) { //possibly overlong
+                        return nextByte & 0xA000000F;
+                    } else if (nextByte == (byte) 0xED) { //possibly surrogate
+                        return nextByte & 0xB000000F;
+                    } else {
+                        return nextByte & 0x9000000F;
+                    }
+                } else if ((nextByte & 0xFC) == 0xF0) { //3 trailing bytes
+                    if (nextByte == (byte) 0xF0) { //possibly overlong
+                        return nextByte & 0x80000007;
+                    } else {
+                        return nextByte & 0xE0000007;
+                    }
+                } else if (nextByte == (byte) 0xF4) { //3 trailing bytes, possibly undefined
+                    //modification from jchardet: don't allow > 0x10FFFF.
+                    return nextByte & 0xD0000007;
+                } else {
+                    return -1;
+                }
+            case 0xE0000000: //3rd-to-last continuation byte
+                if ((nextByte & 0xC0) == 0x80) {
+                    return (currentState << 6) | (nextByte & 0x9000003F);
+                } else {
+                    return -1;
+                }
+            case 0x80000000: //3rd-to-last continuation byte, check overlong
+                // jchardet's (incorrect) version was: 0xA0-0xBF
+                // Need to allow 0x90-0x9F (Supplementary Multilingual Plane) as well!
+                if ((nextByte & 0xE0) == 0xA0 || (nextByte & 0xF0) == 0x90) {
+                    return (currentState << 6) | (nextByte & 0x9000003F);
+                } else {
+                    return -1;
+                }
+            case 0xD0000000: //3rd-to-last continuation byte, check undefined
+                //anything greater than or equal to 0x90 is illegal
+                if ((nextByte & 0xF0) == 0x80) {
+                    return (currentState << 6) | (nextByte & 0x9000003F);
+                } else {
+                    return -1;
+                }
+            case 0x90000000: //2nd-to-last continuation byte
+                if ((nextByte & 0xC0) == 0x80) {
+                    return (currentState << 6) | (nextByte & 0xC000003F);
+                } else {
+                    return -1;
+                }
+            case 0xA0000000: //2nd-to-last continuation byte, check overlong
+                if ((nextByte & 0xE0) == 0xA0) {
+                    return (currentState << 6) | (nextByte & 0xC000003F);
+                } else {
+                    return -1;
+                }
+            case 0xB0000000: //2nd-to-last continuation byte, check surrogate
+                if ((nextByte & 0xE0) == 0x80) {
+                    return (currentState << 6) | (nextByte & 0xC000003F);
+                } else {
+                    return -1;
+                }
+            case 0xC0000000: //last continuation byte
+                if ((nextByte & 0xC0) == 0x80) {
+                    return (currentState << 6) | (nextByte & 0x3F);
+                } else {
+                    return -1;
+                }
+            case 0xF0000000: //error
+                return -1;
+            default:
+                throw new IllegalStateException("illegal state " + Integer.toHexString(currentState));
+        }
+    }
+
+
+    private static Charset charset(String charset) {
+        try {
+            return CharsetUtils.forName(charset);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static final Evaluator charsetMetas = QueryParser
+            .parse("meta[http-equiv=content-type], meta[charset]");
+
+    static Charset htmlCharset(Element root) {
+        for (Element meta : Selector.select(charsetMetas, root)) {
+            Charset foundCharset = charset(meta.attr("charset"));
+            if (foundCharset != null) {
+                return foundCharset;
+            }
+            foundCharset = contentTypeCharset(meta.attr("content"));
+            if (foundCharset != null) {
+                return foundCharset;
+            }
+        }
+        return null;
+    }
+
+
+    private static final Pattern contentTypeCharsetPattern =
+            Pattern.compile("(?i)\\bcharset\\s*=[\\s\"']*([^\\s,;\"']+)");
+
+    static Charset contentTypeCharset(CharSequence contentType) {
+        if (contentType == null)
+            return null;
+        Matcher m = contentTypeCharsetPattern.matcher(contentType);
+        if (m.find()) {
+            try {
+                return CharsetUtils.forName(m.group(1));
+            } catch (Exception e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static final Pattern xmlEncoding = Pattern.compile(
+            "(?is)\\A\\s*<\\?\\s*xml\\s+[^<>]*encoding\\s*=\\s*(?:['\"]\\s*)?([-_:.a-z0-9]+)");
+
+    static Charset xmlCharset(CharSequence str) {
+        Matcher matcher = xmlEncoding.matcher(str);
+        if (matcher.find()) {
+            return charset(matcher.group(1));
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/encoding/src/main/java/org/apache/any23/encoding/EncodingUtils.java
+++ b/encoding/src/main/java/org/apache/any23/encoding/EncodingUtils.java
@@ -72,6 +72,7 @@ class EncodingUtils {
                 if (numInvalid > (numValid + 1) * 10) {
                     return false;
                 }
+                state = 0; //reset state to valid
             } else if (state >= 0) { //state is a valid codepoint
                 //take a hint from jchardet: count SO, SI, ESC as invalid
                 if (state == 0x0E || state == 0x0F || state == 0x1B) {

--- a/encoding/src/main/java/org/apache/any23/encoding/EncodingUtils.java
+++ b/encoding/src/main/java/org/apache/any23/encoding/EncodingUtils.java
@@ -66,6 +66,12 @@ class EncodingUtils {
             state = nextStateUtf8(state, (byte)i);
             if (state == -1) { //bad state
                 numInvalid++;
+
+                //shortcut: avoid reading entire stream
+                //if we can detect early on that it's not UTF-8
+                if (numInvalid > (numValid + 1) * 10) {
+                    return false;
+                }
             } else if (state >= 0) { //state is a valid codepoint
                 //take a hint from jchardet: count SO, SI, ESC as invalid
                 if (state == 0x0E || state == 0x0F || state == 0x1B) {

--- a/encoding/src/main/java/org/apache/any23/encoding/EncodingUtils.java
+++ b/encoding/src/main/java/org/apache/any23/encoding/EncodingUtils.java
@@ -136,50 +136,23 @@ class EncodingUtils {
                     return -1;
                 }
             case 0xE0000000: //3rd-to-last continuation byte
-                if ((nextByte & 0xC0) == 0x80) {
-                    return (currentState << 6) | (nextByte & 0x9000003F);
-                } else {
-                    return -1;
-                }
+                return (nextByte & 0xC0) == 0x80 ? currentState << 6 | nextByte & 0x9000003F : -1;
             case 0x80000000: //3rd-to-last continuation byte, check overlong
                 // jchardet's (incorrect) version was: 0xA0-0xBF
                 // Need to allow 0x90-0x9F (Supplementary Multilingual Plane) as well!
-                if ((nextByte & 0xE0) == 0xA0 || (nextByte & 0xF0) == 0x90) {
-                    return (currentState << 6) | (nextByte & 0x9000003F);
-                } else {
-                    return -1;
-                }
+                return (nextByte & 0xE0) == 0xA0 || (nextByte & 0xF0) == 0x90
+                        ? currentState << 6 | nextByte & 0x9000003F : -1;
             case 0xD0000000: //3rd-to-last continuation byte, check undefined
                 //anything greater than or equal to 0x90 is illegal
-                if ((nextByte & 0xF0) == 0x80) {
-                    return (currentState << 6) | (nextByte & 0x9000003F);
-                } else {
-                    return -1;
-                }
+                return (nextByte & 0xF0) == 0x80 ? currentState << 6 | nextByte & 0x9000003F : -1;
             case 0x90000000: //2nd-to-last continuation byte
-                if ((nextByte & 0xC0) == 0x80) {
-                    return (currentState << 6) | (nextByte & 0xC000003F);
-                } else {
-                    return -1;
-                }
+                return (nextByte & 0xC0) == 0x80 ? currentState << 6 | nextByte & 0xC000003F : -1;
             case 0xA0000000: //2nd-to-last continuation byte, check overlong
-                if ((nextByte & 0xE0) == 0xA0) {
-                    return (currentState << 6) | (nextByte & 0xC000003F);
-                } else {
-                    return -1;
-                }
+                return (nextByte & 0xE0) == 0xA0 ? currentState << 6 | nextByte & 0xC000003F : -1;
             case 0xB0000000: //2nd-to-last continuation byte, check surrogate
-                if ((nextByte & 0xE0) == 0x80) {
-                    return (currentState << 6) | (nextByte & 0xC000003F);
-                } else {
-                    return -1;
-                }
+                return (nextByte & 0xE0) == 0x80 ? currentState << 6 | nextByte & 0xC000003F : -1;
             case 0xC0000000: //last continuation byte
-                if ((nextByte & 0xC0) == 0x80) {
-                    return (currentState << 6) | (nextByte & 0x3F);
-                } else {
-                    return -1;
-                }
+                return (nextByte & 0xC0) == 0x80 ? currentState << 6 | nextByte & 0x3F : -1;
             case 0xF0000000: //error
                 return -1;
             default:

--- a/encoding/src/main/java/org/apache/any23/encoding/EncodingUtils.java
+++ b/encoding/src/main/java/org/apache/any23/encoding/EncodingUtils.java
@@ -44,7 +44,6 @@ class EncodingUtils {
         byte[] buffer = new byte[8192];
         int n;
         while ((n = is.read(buffer)) != -1) {
-            chars.ensureCapacity(chars.length() + n);
             for (int i = 0; i < n; i++) {
                 chars.append((char)(buffer[i] & 0xFF));
             }
@@ -52,25 +51,98 @@ class EncodingUtils {
         return chars.toString();
     }
 
-    //get correct ISO-8859-1 variant
+
+    //get correct variant, or null if charset is incompatible with stats
     static Charset correctVariant(TextStatistics stats, Charset charset) {
-        switch (charset.name().toLowerCase()) {
-            case "iso-8859-1":
+        if (charset == null) {
+            return null;
+        }
+        switch (charset.name()) {
+            //ISO-8859-1 variants
+            case "ISO-8859-1":
                 //Take a hint from icu4j's CharsetRecog_8859_1 and Tika's UniversalEncodingListener:
                 // return windows-1252 before ISO-8859-1 if:
                 // (1) C1 ctrl chars are used (as in icu4j), or
                 // (2) '\r' is used (as in Tika)
-                if ((stats.count('\r') != 0 || hasC1Control(stats)) && canBeWindows1252(stats)) {
+                if ((stats.count('\r') != 0 || hasC1Control(stats)) && hasNoneOf(stats, windows1252Illegals)) {
                     try {
-                        return CharsetUtils.forName("windows-1252");
+                        return forName("windows-1252");
                     } catch (Exception e) {
                         //ignore
                     }
                 }
-
                 return iso_8859_1_or_15(stats);
             case "windows-1252":
-                return canBeWindows1252(stats) ? charset : iso_8859_1_or_15(stats);
+                return hasNoneOf(stats, windows1252Illegals) ? charset : iso_8859_1_or_15(stats);
+
+            //ISO-8859-2 variants
+            case "ISO-8859-2":
+                //Take a hint from icu4j's CharsetRecog_8859_2 class:
+                // return windows-1250 before ISO-8859-2 if has valid C1 chars
+                if (hasC1Control(stats) && hasNoneOf(stats, windows1250Illegals)) {
+                    try {
+                        return forName("windows-1250");
+                    } catch (Exception e) {
+                        //ignore
+                    }
+                }
+                return charset;
+            case "windows-1250":
+                return hasNoneOf(stats, windows1250Illegals) ? charset : charset("ISO-8859-2");
+
+            //ISO-8859-7 variants
+            case "ISO-8859-7":
+                //Take a hint from icu4j's CharsetRecog_8859_7 class:
+                // return windows-1253 before ISO-8859-7 if has valid C1 chars
+                if (hasC1Control(stats) && hasNoneOf(stats, windows1253Illegals)) {
+                    try {
+                        return forName("windows-1253");
+                    } catch (Exception e) {
+                        //ignore
+                    }
+                }
+                return hasNoneOf(stats, iso_8859_7Illegals) ? charset : null;
+            case "windows-1253":
+                return hasNoneOf(stats, windows1253Illegals) ? charset :
+                        hasNoneOf(stats, iso_8859_7Illegals) ? charset("ISO-8859-7") : null;
+
+            //ISO-8859-8 variants
+            case "ISO-8859-8":
+            case "ISO-8859-8-I":
+                //Take a hint from icu4j's CharsetRecog_8859_8 class:
+                // return windows-1255 before ISO-8859-8 if has valid C1 chars
+                if (hasC1Control(stats) && hasNoneOf(stats, windows1255Illegals)) {
+                    try {
+                        return forName("windows-1255");
+                    } catch (Exception e) {
+                        //ignore
+                    }
+                }
+                return hasNoneOf(stats, iso_8859_8Illegals) ? charset : null;
+            case "windows-1255":
+                return hasNoneOf(stats, windows1255Illegals) ? charset :
+                        hasNoneOf(stats, iso_8859_8Illegals) ? charset("ISO-8859-8") : null;
+
+            //ISO-8859-9 variants
+            case "ISO-8859-9":
+                //Take a hint from icu4j's CharsetRecog_8859_9 class:
+                // return windows-1254 before ISO-8859-9 if has valid C1 chars
+                if (hasC1Control(stats) && hasNoneOf(stats, windows1254Illegals)) {
+                    try {
+                        return forName("windows-1254");
+                    } catch (Exception e) {
+                        //ignore
+                    }
+                }
+                return charset;
+            case "windows-1254":
+                return hasNoneOf(stats, windows1254Illegals) ? charset : charset("ISO-8859-9");
+
+            //Others: just make sure no illegal characters are present
+            case "windows-1251":
+                return hasNoneOf(stats, windows1251Illegals) ? charset : null;
+            case "ISO-8859-6":
+                return hasNoneOf(stats, iso_8859_6Illegals) ? charset : null;
             default:
                 return charset;
         }
@@ -81,7 +153,7 @@ class EncodingUtils {
         // return ISO-8859-15 before ISO-8859-1 if currency/euro symbol is used
         if (stats.count(0xa4) != 0) {
             try {
-                return CharsetUtils.forName("ISO-8859-15");
+                return forName("ISO-8859-15");
             } catch (Exception e) {
                 //ignore
             }
@@ -89,16 +161,41 @@ class EncodingUtils {
         return StandardCharsets.ISO_8859_1;
     }
 
+    private static final int[] windows1252Illegals = {0x81, 0x8D, 0x8F, 0x90, 0x9D};
+    private static final int[] windows1250Illegals = {0x81, 0x83, 0x88, 0x90, 0x98};
+    private static final int[] iso_8859_7Illegals = {0xAE, 0xD2, 0xFF};
+    private static final int[] windows1253Illegals = {0x81, 0x88, 0x8A, 0x8C, 0x8D,
+            0x8E, 0x8F, 0x90, 0x98, 0x9A, 0x9C, 0x9D, 0x9E, 0x9F, 0xAA, 0xD2, 0xFF};
 
-    private static boolean canBeWindows1252(TextStatistics stats) {
-        //these C1 chars are not defined in windows-1252
-        return (stats.count(0x81) | stats.count(0x8D) | stats.count(0x8F)
-                | stats.count(0x90) | stats.count(0x9D)) == 0;
+    private static final int[] windows1255Illegals = {0x81, 0x8A, 0x8C, 0x8D, 0x8E, 0x8F, 0x90, 0x9A,
+            0x9C, 0x9D, 0x9E, 0x9F, 0xCA, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF, 0xFB, 0xFC, 0xFF};
+
+    private static final int[] iso_8859_8Illegals = {0xA1, 0xBF, 0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5,
+            0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF, 0xD0, 0xD1, 0xD2, 0xD3, 0xD4,
+            0xD5, 0xD6, 0xD7, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xFB, 0xFC, 0xFF};
+
+    private static final int[] windows1254Illegals = {0x81, 0x8D, 0x8E, 0x8F, 0x90, 0x9D, 0x9E};
+
+    private static final int[] windows1251Illegals = {0x98};
+
+    private static final int[] iso_8859_6Illegals = {0xA1, 0xA2, 0xA3, 0xA5, 0xA6, 0xA7,
+            0xA8, 0xA9, 0xAA, 0xAB, 0xAE, 0xAF, 0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6,
+            0xB7, 0xB8, 0xB9, 0xBA, 0xBC, 0xBD, 0xBE, 0xC0, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF,
+            0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF};
+
+
+    private static boolean hasNoneOf(TextStatistics stats, int[] illegals) {
+        for (int i : illegals) {
+            if (stats.count(i) != 0) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static boolean hasC1Control(TextStatistics ts) {
         for (int i = 0x80; i < 0xA0; i++) {
-            if (ts.count(i) > 0) {
+            if (ts.count(i) != 0) {
                 return true;
             }
         }
@@ -232,9 +329,29 @@ class EncodingUtils {
     }
 
 
-    private static Charset charset(String charset) {
+    static Charset forName(String charset) throws Exception {
         try {
             return CharsetUtils.forName(charset);
+        } catch (Exception e) {
+            //ICU4j sometimes returns 'ISO-8859-8-I', which is unsupported!
+            // Cf. https://en.wikipedia.org/wiki/ISO/IEC_8859-8
+            // "Nominally ISO-8859-8 (code page 28598) is for 'visual order',
+            // and ISO-8859-8-I (code page 38598) is for logical order.
+            // But usually in practice, and required for HTML and XML
+            // documents, ISO-8859-8 also stands for logical order text."
+            charset = charset.replaceAll("(?i)-I\\b", "");
+            try {
+                return CharsetUtils.forName(charset);
+            } catch (Exception e1) {
+                //ignore
+            }
+            throw e;
+        }
+    }
+
+    private static Charset charset(String charset) {
+        try {
+            return forName(charset);
         } catch (Exception e) {
             return null;
         }
@@ -243,13 +360,13 @@ class EncodingUtils {
     private static final Evaluator charsetMetas = QueryParser
             .parse("meta[http-equiv=content-type], meta[charset]");
 
-    static Charset htmlCharset(Element root) {
+    static Charset htmlCharset(TextStatistics stats, Element root) {
         for (Element meta : Selector.select(charsetMetas, root)) {
-            Charset foundCharset = charset(meta.attr("charset"));
+            Charset foundCharset = correctVariant(stats, charset(meta.attr("charset")));
             if (foundCharset != null) {
                 return foundCharset;
             }
-            foundCharset = contentTypeCharset(meta.attr("content"));
+            foundCharset = correctVariant(stats, contentTypeCharset(meta.attr("content")));
             if (foundCharset != null) {
                 return foundCharset;
             }
@@ -267,7 +384,7 @@ class EncodingUtils {
         Matcher m = contentTypeCharsetPattern.matcher(contentType);
         if (m.find()) {
             try {
-                return CharsetUtils.forName(m.group(1));
+                return forName(m.group(1));
             } catch (Exception e) {
                 return null;
             }
@@ -278,13 +395,44 @@ class EncodingUtils {
     private static final Pattern xmlEncoding = Pattern.compile(
             "(?is)\\A\\s*<\\?\\s*xml\\s+[^<>]*encoding\\s*=\\s*(?:['\"]\\s*)?([-_:.a-z0-9]+)");
 
-    static Charset xmlCharset(CharSequence str) {
+    static Charset xmlCharset(TextStatistics stats, CharSequence str) {
         Matcher matcher = xmlEncoding.matcher(str);
         if (matcher.find()) {
-            return charset(matcher.group(1));
+            return correctVariant(stats, charset(matcher.group(1)));
         } else {
             return null;
         }
     }
+
+
+    //uncomment this handy function to print out invalid bytes for a charset
+//    public static void main(String[] args) throws Exception {
+//        String[] cs = {
+//                "ISO-8859-15",
+//                "windows-1252", "ISO-8859-1",
+//                "windows-1250", "ISO-8859-2",
+//                "windows-1253", "ISO-8859-7",
+//                "windows-1255", "ISO-8859-8",
+//                "windows-1254", "ISO-8859-9",
+//                "windows-1251",
+//                "windows-1256",
+//                "ISO-8859-5",
+//                "ISO-8859-6"
+//        };
+//
+//        for (String name : cs) {
+//            System.out.println(IntStream.range(0, 256).filter(i -> {
+//                try {
+//                    Charset c = EncodingUtils.forName(name);
+//                    String s = new String(new byte[]{(byte) i}, c);
+//                    byte[] bytes = s.getBytes(c);
+//                    return bytes.length != 1 || bytes[0] != (byte)i;
+//                } catch (Exception e) {
+//                    throw new RuntimeException(e);
+//                }
+//            }).mapToObj(i -> "0x" + Integer.toHexString(i).toUpperCase())
+//                    .collect(Collectors.joining(", ", "undefined " + name + " = {", "};")));
+//        }
+//    }
 
 }

--- a/encoding/src/main/java/org/apache/any23/encoding/TikaEncodingDetector.java
+++ b/encoding/src/main/java/org/apache/any23/encoding/TikaEncodingDetector.java
@@ -17,21 +17,39 @@
 
 package org.apache.any23.encoding;
 
-import org.apache.tika.metadata.Metadata;
-import org.apache.tika.mime.MediaType;
-import org.apache.tika.parser.html.HtmlEncodingDetector;
 import org.apache.tika.parser.txt.CharsetDetector;
 import org.apache.tika.parser.txt.CharsetMatch;
 import org.apache.tika.utils.CharsetUtils;
+import org.jsoup.nodes.Comment;
+import org.jsoup.nodes.DataNode;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.DocumentType;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.PseudoTextElement;
+import org.jsoup.nodes.TextNode;
+import org.jsoup.parser.ParseErrorList;
+import org.jsoup.parser.Parser;
+import org.jsoup.select.Evaluator;
+import org.jsoup.select.NodeTraversor;
+import org.jsoup.select.NodeVisitor;
+import org.jsoup.select.QueryParser;
+import org.jsoup.select.Selector;
 
-import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
  * An implementation of {@link EncodingDetector} based on
@@ -46,74 +64,360 @@ public class TikaEncodingDetector implements EncodingDetector {
 
     @Override
     public String guessEncoding(InputStream input) throws IOException {
-        return guessEncoding(input, null);
+        return guessEncoding(input, (String)null);
     }
 
-    @Override
-    public String guessEncoding(InputStream is, String contentType) throws IOException {
-        if (!is.markSupported()) {
-            is = new BufferedInputStream(is);
+    private static Charset charset(String charset) {
+        try {
+            return CharsetUtils.forName(charset);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static Charset xmlCharset(CharSequence str) {
+        Matcher matcher = xmlEncoding.matcher(str);
+        if (matcher.find()) {
+            return charset(matcher.group(1));
+        } else {
+            return null;
+        }
+    }
+
+    private static final Evaluator charsetMetas = QueryParser
+            .parse("meta[http-equiv=content-type], meta[charset]");
+
+    private static Charset htmlCharset(Element root) {
+        for (Element meta : Selector.select(charsetMetas, root)) {
+            Charset foundCharset = charset(meta.attr("charset"));
+            if (foundCharset != null) {
+                return foundCharset;
+            }
+            foundCharset = contentTypeCharset(meta.attr("content"));
+            if (foundCharset != null) {
+                return foundCharset;
+            }
+        }
+        return null;
+    }
+
+    // Very efficient method to convert an input stream directly to an ISO-8859-1 encoded string
+    private static String iso_8859_1(InputStream is) throws IOException {
+        final boolean mark = is.markSupported();
+        if (mark) {
+            is.mark(Integer.MAX_VALUE);
+        }
+        StringBuilder chars = new StringBuilder(8192);
+        byte[] buffer = new byte[8192];
+        int n;
+        try {
+            while ((n = is.read(buffer)) != -1) {
+                chars.ensureCapacity(chars.length() + n);
+                for (int i = 0; i < n; i++) {
+                    chars.append((char) buffer[i]);
+                }
+            }
+        } finally {
+            if (mark) {
+                is.reset();
+            }
+        }
+        return chars.toString();
+    }
+
+    private static final String TAG_CHARS = "< />";
+    private static final byte[] TAG_BYTES = TAG_CHARS.getBytes(UTF_8);
+    private static final Node[] EMPTY_NODES = new Node[0];
+
+    private static Document parseFragment(String html, ParseErrorList errors) {
+        Document doc = new Document("");
+        Node[] childNodes = Parser.parseFragment(html, null, "", errors).toArray(EMPTY_NODES);
+        for (Node node : childNodes) {
+            if (node.parentNode() != null) {
+                node.remove();
+            }
+            doc.appendChild(node);
+        }
+        return doc;
+    }
+
+    private static long openTags(Node node) {
+        long[] ret = {0};
+        NodeTraversor.traverse(new NodeVisitor() {
+            @Override
+            public void head(Node node, int depth) {
+                if (node instanceof Document || node instanceof PseudoTextElement) {
+                    //subclasses of Element that don't have start/end tags
+                    return;
+                }
+                if (node instanceof Element || node instanceof DocumentType || node instanceof Comment) {
+                    ret[0] += node.childNodeSize() == 0 ? 1 : 2;
+                }
+            }
+            @Override
+            public void tail(Node node, int depth) {
+            }
+        }, node);
+        return ret[0];
+    }
+
+    private static String wholeText(Node node) {
+        StringBuilder sb = new StringBuilder();
+        NodeTraversor.traverse(new NodeVisitor() {
+            @Override
+            public void head(Node node, int depth) {
+                if (node instanceof TextNode) {
+                    sb.append(((TextNode) node).getWholeText());
+                } else if (node instanceof DataNode) {
+                    String data = ((DataNode) node).getWholeData();
+                    do {
+                        //make sure json-ld data is included in text stats
+                        //otherwise, ignore css & javascript
+                        if ("script".equalsIgnoreCase(node.nodeName())) {
+                            if (node.attr("type").toLowerCase().contains("json")) {
+                                sb.append(data);
+                            }
+                            break;
+                        } else if ("style".equalsIgnoreCase(node.nodeName())) {
+                            break;
+                        }
+                        node = node.parentNode();
+                    } while (node != null);
+                } else if (node instanceof Comment) {
+                    String data = ((Comment) node).getData();
+                    //avoid comments that are actually processing instructions or xml declarations
+                    if (!data.contains("<!") && !data.contains("<?")) {
+                        sb.append(data);
+                    }
+                } else if (node instanceof Element) {
+                    //make sure all microdata itemprop "content" values are taken into consideration
+                    sb.append(node.attr("content"));
+                }
+            }
+            @Override
+            public void tail(Node node, int depth) {
+            }
+        }, node);
+        return sb.toString();
+    }
+
+    private static final double z = 1.96;
+    private static double wilsonScoreLowerBound(double p, double n) {
+        if (n < 1) {
+            return 0;
+        }
+        final double z2_n = z*z/n;
+        return ((p + z2_n * 0.5) - z * Math.sqrt((p*(1-p) + z2_n*0.25)/n)) / (1 + z2_n);
+    }
+    private static int wilsonScoreLowerBoundPercent(int p, double n) {
+        return (int)(wilsonScoreLowerBound(p / 100.0, n) * 100.0);
+    }
+
+    //Adapted from icu4j's CharsetRecog_UTF8 class to accept ISO-8859-1 string
+    private static Boolean isUtf8(String iso_8859_1) {
+        boolean     hasBOM = false;
+        int         numValid = 0;
+        int         numInvalid = 0;
+        int         i;
+        int         trailBytes;
+        final int length = iso_8859_1.length();
+        if (length >= 3 &&
+                (iso_8859_1.charAt(0) & 0xFF) == 0xef && (iso_8859_1.charAt(1) & 0xFF) == 0xbb && (iso_8859_1.charAt(2) & 0xFF) == 0xbf) {
+            hasBOM = true;
         }
 
-        Charset xmlCharset = detectXmlEncoding(is, 1024);
+        // Scan for multi-byte sequences
+        for (i = 0; i < length; i++) {
+            int b = iso_8859_1.charAt(i);
+            if ((b & 0x80) == 0) {
+                continue;   // ASCII
+            }
+            // Hi bit on char found.  Figure out how long the sequence should be
+            if ((b & 0x0e0) == 0x0c0) {
+                trailBytes = 1;
+            } else if ((b & 0x0f0) == 0x0e0) {
+                trailBytes = 2;
+            } else if ((b & 0x0f8) == 0xf0) {
+                trailBytes = 3;
+            } else {
+                numInvalid++;
+                continue;
+            }
 
-        HtmlEncodingDetector htmlEncodingDetector = new HtmlEncodingDetector();
-        htmlEncodingDetector.setMarkLimit(16384);
-        Charset htmlCharset = htmlEncodingDetector.detect(is, new Metadata());
-
-        CharsetDetector charsetDetector = new CharsetDetector(65536);
-
-        String incomingCharset = null;
-        if (contentType != null) {
-            MediaType mt = MediaType.parse(contentType);
-            if (mt != null) {
-                incomingCharset = mt.getParameters().get("charset");
+            // Verify that we've got the right number of trail bytes in the sequence
+            for (;;) {
+                i++;
+                if (i>=length) {
+                    break;
+                }
+                b = iso_8859_1.charAt(i);
+                if ((b & 0xc0) != 0x080) {
+                    numInvalid++;
+                    break;
+                }
+                if (--trailBytes == 0) {
+                    numValid++;
+                    break;
+                }
             }
         }
 
-        if (incomingCharset != null) {
-            incomingCharset = CharsetUtils.clean(incomingCharset);
-            if (incomingCharset != null) {
-                charsetDetector.setDeclaredEncoding(incomingCharset);
-            }
+        if (hasBOM && numValid >= numInvalid * 10) {
+            //includes case where numValid == numInvalid == 0
+            return Boolean.TRUE;
+        } else if (numValid == 0 && numInvalid == 0) {
+            // Plain ASCII
+            return null;
+        } else if (numValid > numInvalid * 10) {
+            return Boolean.TRUE;
+        } else {
+            return Boolean.FALSE;
         }
+    }
 
-        //enableInputFilter() needs to precede setText() to have any effect
-        charsetDetector.enableInputFilter(true);
-        charsetDetector.setText(is);
+    private static Charset guessEncoding(InputStream is, Charset declared) throws IOException {
+        Charset xmlCharset;
+        Charset htmlCharset;
+        boolean filterInput;
+        byte[] text;
+        CharsetDetector icu4j;
+        {
+            // ISO-8859-1 is Java's only "standard charset" which maps 1-to-1 onto the first 256 unicode characters;
+            // use ISO-8859-1 for round-tripping of bytes after stripping html/xml tags from input
+            String iso_8859_1 = iso_8859_1(is);
+            Boolean utf8 = isUtf8(iso_8859_1);
+
+            if (Boolean.TRUE.equals(utf8)) {
+                // > 92% of the web is UTF-8. Do not risk false positives from obscure charsets.
+                // See https://issues.apache.org/jira/browse/TIKA-2771
+                return UTF_8;
+            }
+
+            if (utf8 == null && declared != null) {
+                // All characters are plain ASCII.
+                // Here, it doesn't really matter what charset we detect, as we'll
+                // get same data out. Use declared charset if available.
+                return declared;
+            }
+
+            xmlCharset = xmlCharset(iso_8859_1);
+
+            if (utf8 == null && xmlCharset != null) {
+                // All characters are plain ASCII, so it doesn't matter what we choose.
+                // Use xml encoding if available.
+                return xmlCharset;
+            }
+
+            ParseErrorList errors = ParseErrorList.tracking(Integer.MAX_VALUE);
+
+            Document doc = parseFragment(iso_8859_1, errors);
+
+            htmlCharset = htmlCharset(doc);
+
+            if (utf8 == null) {
+                // All characters are plain ASCII, so it doesn't matter what we choose.
+                // Use html meta charset if available. Otherwise, UTF-8.
+                return htmlCharset != null ? htmlCharset : UTF_8;
+            }
+
+            // Here, it's probably not UTF-8.
+            // Wait for more text statistics before returning any of the declared charsets.
+            // See https://issues.apache.org/jira/browse/TIKA-539
+
+            long openTags = openTags(doc);
+            long badTags = errors.stream().filter(err -> err.getErrorMessage().matches(".*'[</>]'.*")).count();
+            String wholeText = wholeText(doc);
+
+            //condition for filtering input based roughly on icu4j's CharsetDetector#MungeInput()
+            if (openTags < 5 || openTags / 5 < badTags ||
+                    (wholeText.length() < 100 && iso_8859_1.length() > 600)) {
+                filterInput = false;
+            } else {
+                filterInput = true;
+                iso_8859_1 = wholeText;
+            }
+            text = iso_8859_1.getBytes(ISO_8859_1);
+
+            icu4j = new CharsetDetector(text.length);
+            icu4j.setText(text);
+        }
 
         Charset bestCharset = null;
         int bestConfidence = 0;
-        for (CharsetMatch match : charsetDetector.detectAll()) {
+        for (CharsetMatch match : icu4j.detectAll()) {
             try {
                 Charset charset = CharsetUtils.forName(match.getName());
                 int confidence = match.getConfidence();
-                if (StandardCharsets.UTF_8.equals(charset)) {
-                    confidence *= 4;
+                if (confidence <= 0) {
+                    continue;
                 }
-                if (charset.equals(htmlCharset) || charset.equals(xmlCharset)) {
-                    confidence *= 16;
+                // If we successfully filtered input based on 0x3C and 0x3E, then this must be an ascii-compatible charset
+                // See https://issues.apache.org/jira/browse/TIKA-2771
+                if (filterInput && !TAG_CHARS.equals(new String(TAG_BYTES, charset))) {
+                    continue;
                 }
-                if (charset.name().equals(incomingCharset)) {
-                    confidence *= 16;
+
+                Reader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(text), charset));
+                int ch;
+                long byteCountAlpha = 0;
+                while ((ch = reader.read()) != -1) {
+                    if (Character.isHighSurrogate((char)ch)) {
+                        int lo = reader.read();
+                        if (lo == -1) {
+                            break;
+                        }
+                        int codePoint = Character.toCodePoint((char)ch, (char)lo);
+                        if (Character.isAlphabetic(codePoint) || Character.isIdeographic(codePoint)) {
+                            byteCountAlpha += new String(new char[]{(char)ch, (char)lo}).getBytes(charset).length;
+                        }
+                    } else if (Character.isAlphabetic(ch) || Character.isIdeographic(ch)) {
+                        byteCountAlpha += new String(new char[]{(char)ch}).getBytes(charset).length;
+                    }
                 }
+
+                // For charsets detected based on frequency statistics, reduce confidence relative to
+                // declared charsets' stated confidence, using the lower bound of the wilson score confidence interval,
+                // taking the initial confidence to be p and the total number of alphabetic bytes to be n.
+                // See https://issues.apache.org/jira/browse/TIKA-2771
+                confidence = wilsonScoreLowerBoundPercent(confidence, byteCountAlpha);
+
+                if (charset.equals(declared) || charset.equals(xmlCharset) || charset.equals(htmlCharset)) {
+                    confidence = (100 + confidence) / 2; //take arithmetic mean, as in icu4j
+                }
+
                 if (confidence > bestConfidence) {
                     bestCharset = charset;
                     bestConfidence = confidence;
                 }
             } catch (Exception e) {
-                    //ignore
+                //ignore; if this charset isn't supported by this platform, it's probably not correct anyway.
             }
         }
 
-        if (bestConfidence >= 100)
-            return bestCharset.name();
-        if (htmlCharset != null)
-            return htmlCharset.name();
-        if (xmlCharset != null)
-            return xmlCharset.name();
-        if (bestCharset != null)
-            return bestCharset.name();
+        return bestCharset != null ? bestCharset : declared;
+    }
+
+    @Override
+    public String guessEncoding(InputStream is, String contentType) throws IOException {
+        Charset charset = contentTypeCharset(contentType);
+        Charset best = guessEncoding(is, charset);
+        return best == null ? null : best.name();
+    }
+
+    private static final Pattern contentTypeCharsetPattern =
+            Pattern.compile("(?i)\\bcharset\\s*=[\\s\"']*([^\\s,;\"']+)");
+
+    private static Charset contentTypeCharset(CharSequence contentType) {
+        if (contentType == null)
+            return null;
+        Matcher m = contentTypeCharsetPattern.matcher(contentType);
+        if (m.find()) {
+            try {
+                return CharsetUtils.forName(m.group(1));
+            } catch (Exception e) {
+                return null;
+            }
+        }
         return null;
     }
 

--- a/encoding/src/main/java/org/apache/any23/encoding/TikaEncodingDetector.java
+++ b/encoding/src/main/java/org/apache/any23/encoding/TikaEncodingDetector.java
@@ -28,23 +28,16 @@ import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
 import org.jsoup.nodes.PseudoTextElement;
 import org.jsoup.nodes.TextNode;
+import org.jsoup.parser.ParseError;
 import org.jsoup.parser.ParseErrorList;
 import org.jsoup.parser.Parser;
-import org.jsoup.select.Evaluator;
 import org.jsoup.select.NodeTraversor;
 import org.jsoup.select.NodeVisitor;
-import org.jsoup.select.QueryParser;
-import org.jsoup.select.Selector;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.nio.charset.Charset;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
@@ -65,67 +58,124 @@ public class TikaEncodingDetector implements EncodingDetector {
         return guessEncoding(input, (String)null);
     }
 
-    private static Charset charset(String charset) {
-        try {
-            return CharsetUtils.forName(charset);
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    static Charset xmlCharset(CharSequence str) {
-        Matcher matcher = xmlEncoding.matcher(str);
-        if (matcher.find()) {
-            return charset(matcher.group(1));
-        } else {
-            return null;
-        }
-    }
-
-    private static final Evaluator charsetMetas = QueryParser
-            .parse("meta[http-equiv=content-type], meta[charset]");
-
-    private static Charset htmlCharset(Element root) {
-        for (Element meta : Selector.select(charsetMetas, root)) {
-            Charset foundCharset = charset(meta.attr("charset"));
-            if (foundCharset != null) {
-                return foundCharset;
-            }
-            foundCharset = contentTypeCharset(meta.attr("content"));
-            if (foundCharset != null) {
-                return foundCharset;
-            }
-        }
-        return null;
-    }
-
-    // Very efficient method to convert an input stream directly to an ISO-8859-1 encoded string
-    private static String iso_8859_1(InputStream is) throws IOException {
-        final boolean mark = is.markSupported();
-        if (mark) {
-            is.mark(Integer.MAX_VALUE);
-        }
-        StringBuilder chars = new StringBuilder(Math.max(is.available(), 8192));
-        byte[] buffer = new byte[8192];
-        int n;
-        try {
-            while ((n = is.read(buffer)) != -1) {
-                chars.ensureCapacity(chars.length() + n);
-                for (int i = 0; i < n; i++) {
-                    chars.append((char)(buffer[i] & 0xFF));
-                }
-            }
-        } finally {
-            if (mark) {
-                is.reset();
-            }
-        }
-        return chars.toString();
-    }
-
     private static final String TAG_CHARS = "< />";
     private static final byte[] TAG_BYTES = TAG_CHARS.getBytes(UTF_8);
     private static final Node[] EMPTY_NODES = new Node[0];
+
+    private static Charset guessEncoding(InputStream is, Charset declared) throws IOException {
+        if (!is.markSupported()) {
+            is = new BufferedInputStream(is);
+        }
+        is.mark(Integer.MAX_VALUE);
+        Boolean utf8;
+        try {
+            utf8 = EncodingUtils.isUTF8(is);
+            if (utf8 != null && utf8) {
+                // > 92% of the web is UTF-8. Do not risk false positives from obscure charsets.
+                // See https://issues.apache.org/jira/browse/TIKA-2771
+                // and https://issues.apache.org/jira/browse/TIKA-539
+                return UTF_8;
+            }
+        } finally {
+            is.reset();
+        }
+
+        if (declared != null) {
+            return declared;
+        }
+
+        boolean filterInput;
+        byte[] text;
+        {
+            // ISO-8859-1 is Java's only "standard charset" which maps 1-to-1 onto the first 256 unicode characters;
+            // use ISO-8859-1 for round-tripping of bytes after stripping html/xml tags from input
+            String iso_8859_1;
+            is.mark(Integer.MAX_VALUE);
+            try {
+                iso_8859_1 = EncodingUtils.iso_8859_1(is);
+            } finally {
+                is.reset();
+            }
+
+            Charset xmlCharset = EncodingUtils.xmlCharset(iso_8859_1);
+            if (xmlCharset != null) {
+                return xmlCharset;
+            }
+
+            ParseErrorList htmlErrors = ParseErrorList.tracking(Integer.MAX_VALUE);
+            Document doc = parseFragment(iso_8859_1, htmlErrors);
+
+            Charset htmlCharset = EncodingUtils.htmlCharset(doc);
+
+            if (htmlCharset != null) {
+                return htmlCharset;
+            }
+
+            if (utf8 == null) {
+                // All characters are plain ASCII, so it doesn't matter what we choose.
+                return UTF_8;
+            }
+
+            long openTags = countTags(doc);
+            long badTags = htmlErrors.stream().map(ParseError::getErrorMessage)
+                    .filter(err -> err != null && err.matches(".*'[</>]'.*")).count();
+
+            //condition for filtering input adapted from icu4j's CharsetDetector#MungeInput()
+            if (openTags < 5 || openTags / 5 < badTags) {
+                filterInput = false;
+            } else {
+                String wholeText = wholeText(doc);
+                if (wholeText.length() < 100 && iso_8859_1.length() > 600) {
+                    filterInput = false;
+                } else {
+                    filterInput = true;
+                    iso_8859_1 = wholeText;
+                }
+            }
+            text = iso_8859_1.getBytes(ISO_8859_1);
+        }
+
+        CharsetDetector icu4j = new CharsetDetector(text.length);
+        icu4j.setText(text);
+
+        for (CharsetMatch match : icu4j.detectAll()) {
+            try {
+                int confidence = match.getConfidence();
+                if (confidence <= 0) {
+                    continue;
+                }
+
+                Charset charset = CharsetUtils.forName(match.getName());
+
+                // If we successfully filtered input based on 0x3C and 0x3E, then this must be an ascii-compatible charset
+                // See https://issues.apache.org/jira/browse/TIKA-2771
+                if (filterInput && !TAG_CHARS.equals(new String(TAG_BYTES, charset))) {
+                    continue;
+                }
+
+                return charset;
+            } catch (Exception e) {
+                //ignore; if this charset isn't supported by this platform, it's probably not correct anyway.
+            }
+        }
+
+        // No bytes are invalid in ISO-8859-1, so this one is always possible if there are no options left.
+        // Also, has second-highest popularity on the web behind UTF-8.
+        return ISO_8859_1;
+    }
+
+    @Override
+    public String guessEncoding(InputStream is, String contentType) throws IOException {
+        Charset charset = EncodingUtils.contentTypeCharset(contentType);
+        Charset best = guessEncoding(is, charset);
+        return best == null ? null : best.name();
+    }
+
+
+
+    //////////////////////////
+    // JSOUP HELPER METHODS //
+    //////////////////////////
 
     private static Document parseFragment(String html, ParseErrorList errors) {
         Document doc = new Document("");
@@ -139,7 +189,7 @@ public class TikaEncodingDetector implements EncodingDetector {
         return doc;
     }
 
-    private static long openTags(Node node) {
+    private static long countTags(Node node) {
         long[] ret = {0};
         NodeTraversor.traverse(new NodeVisitor() {
             @Override
@@ -199,226 +249,4 @@ public class TikaEncodingDetector implements EncodingDetector {
         return sb.toString();
     }
 
-    private static final double z = 1.96;
-    private static double wilsonScoreLowerBound(double p, double n) {
-        if (n < 1) {
-            return 0;
-        }
-        final double z2_n = z*z/n;
-        return ((p + z2_n * 0.5) - z * Math.sqrt((p*(1-p) + z2_n*0.25)/n)) / (1 + z2_n);
-    }
-    private static int wilsonScoreLowerBoundPercent(int p, double n) {
-        return (int)(wilsonScoreLowerBound(p / 100.0, n) * 100.0);
-    }
-
-    //Adapted from icu4j's CharsetRecog_UTF8 class to accept ISO-8859-1 string
-    private static Boolean isUtf8(String iso_8859_1) {
-        boolean     hasBOM = false;
-        int         numValid = 0;
-        int         numInvalid = 0;
-        int         i;
-        int         trailBytes;
-        final int length = iso_8859_1.length();
-        if (length >= 3 &&
-                (iso_8859_1.charAt(0) & 0xFF) == 0xef && (iso_8859_1.charAt(1) & 0xFF) == 0xbb && (iso_8859_1.charAt(2) & 0xFF) == 0xbf) {
-            hasBOM = true;
-        }
-
-        // Scan for multi-byte sequences
-        for (i = 0; i < length; i++) {
-            int b = iso_8859_1.charAt(i);
-            if ((b & 0x80) == 0) {
-                continue;   // ASCII
-            }
-            // Hi bit on char found.  Figure out how long the sequence should be
-            if ((b & 0x0e0) == 0x0c0) {
-                trailBytes = 1;
-            } else if ((b & 0x0f0) == 0x0e0) {
-                trailBytes = 2;
-            } else if ((b & 0x0f8) == 0xf0) {
-                trailBytes = 3;
-            } else {
-                numInvalid++;
-                continue;
-            }
-
-            // Verify that we've got the right number of trail bytes in the sequence
-            for (;;) {
-                i++;
-                if (i>=length) {
-                    break;
-                }
-                b = iso_8859_1.charAt(i);
-                if ((b & 0xc0) != 0x080) {
-                    numInvalid++;
-                    break;
-                }
-                if (--trailBytes == 0) {
-                    numValid++;
-                    break;
-                }
-            }
-        }
-
-        if (hasBOM && numValid >= numInvalid * 10) {
-            //includes case where numValid == numInvalid == 0
-            return Boolean.TRUE;
-        } else if (numValid == 0 && numInvalid == 0) {
-            // Plain ASCII
-            return null;
-        } else if (numValid > numInvalid * 10) {
-            return Boolean.TRUE;
-        } else {
-            return Boolean.FALSE;
-        }
-    }
-
-    private static Charset guessEncoding(InputStream is, Charset declared) throws IOException {
-        Charset xmlCharset;
-        Charset htmlCharset;
-        boolean filterInput;
-        byte[] text;
-        CharsetDetector icu4j;
-        {
-            // ISO-8859-1 is Java's only "standard charset" which maps 1-to-1 onto the first 256 unicode characters;
-            // use ISO-8859-1 for round-tripping of bytes after stripping html/xml tags from input
-            String iso_8859_1 = iso_8859_1(is);
-            Boolean utf8 = isUtf8(iso_8859_1);
-
-            if (Boolean.TRUE.equals(utf8)) {
-                // > 92% of the web is UTF-8. Do not risk false positives from obscure charsets.
-                // See https://issues.apache.org/jira/browse/TIKA-2771
-                return UTF_8;
-            }
-
-            if (utf8 == null && declared != null) {
-                // All characters are plain ASCII.
-                // Here, it doesn't really matter what charset we detect, as we'll
-                // get same data out. Use declared charset if available.
-                return declared;
-            }
-
-            xmlCharset = xmlCharset(iso_8859_1);
-
-            if (utf8 == null && xmlCharset != null) {
-                // All characters are plain ASCII, so it doesn't matter what we choose.
-                // Use xml encoding if available.
-                return xmlCharset;
-            }
-
-            ParseErrorList errors = ParseErrorList.tracking(Integer.MAX_VALUE);
-
-            Document doc = parseFragment(iso_8859_1, errors);
-
-            htmlCharset = htmlCharset(doc);
-
-            if (utf8 == null) {
-                // All characters are plain ASCII, so it doesn't matter what we choose.
-                // Use html meta charset if available. Otherwise, UTF-8.
-                return htmlCharset != null ? htmlCharset : UTF_8;
-            }
-
-            // Here, it's probably not UTF-8.
-            // Wait for more text statistics before returning any of the declared charsets.
-            // See https://issues.apache.org/jira/browse/TIKA-539
-
-            long openTags = openTags(doc);
-            long badTags = errors.stream().filter(err -> err.getErrorMessage().matches(".*'[</>]'.*")).count();
-            String wholeText = wholeText(doc);
-
-            //condition for filtering input based roughly on icu4j's CharsetDetector#MungeInput()
-            if (openTags < 5 || openTags / 5 < badTags ||
-                    (wholeText.length() < 100 && iso_8859_1.length() > 600)) {
-                filterInput = false;
-            } else {
-                filterInput = true;
-                iso_8859_1 = wholeText;
-            }
-            text = iso_8859_1.getBytes(ISO_8859_1);
-
-            icu4j = new CharsetDetector(text.length);
-            icu4j.setText(text);
-        }
-
-        Charset bestCharset = null;
-        int bestConfidence = 0;
-        for (CharsetMatch match : icu4j.detectAll()) {
-            try {
-                Charset charset = CharsetUtils.forName(match.getName());
-                int confidence = match.getConfidence();
-                if (confidence <= 0) {
-                    continue;
-                }
-                // If we successfully filtered input based on 0x3C and 0x3E, then this must be an ascii-compatible charset
-                // See https://issues.apache.org/jira/browse/TIKA-2771
-                if (filterInput && !TAG_CHARS.equals(new String(TAG_BYTES, charset))) {
-                    continue;
-                }
-
-                Reader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(text), charset));
-                int ch;
-                long byteCountAlpha = 0;
-                while ((ch = reader.read()) != -1) {
-                    if (Character.isHighSurrogate((char)ch)) {
-                        int lo = reader.read();
-                        if (lo == -1) {
-                            break;
-                        }
-                        int codePoint = Character.toCodePoint((char)ch, (char)lo);
-                        if (Character.isAlphabetic(codePoint) || Character.isIdeographic(codePoint)) {
-                            byteCountAlpha += new String(new char[]{(char)ch, (char)lo}).getBytes(charset).length;
-                        }
-                    } else if (Character.isAlphabetic(ch) || Character.isIdeographic(ch)) {
-                        byteCountAlpha += new String(new char[]{(char)ch}).getBytes(charset).length;
-                    }
-                }
-
-                // For charsets detected based on frequency statistics, reduce confidence relative to
-                // declared charsets' stated confidence, using the lower bound of the wilson score confidence interval,
-                // taking the initial confidence to be p and the total number of alphabetic bytes to be n.
-                // See https://issues.apache.org/jira/browse/TIKA-2771
-                confidence = wilsonScoreLowerBoundPercent(confidence, byteCountAlpha);
-
-                if (charset.equals(declared) || charset.equals(xmlCharset) || charset.equals(htmlCharset)) {
-                    confidence = (100 + confidence) / 2; //take arithmetic mean, as in icu4j
-                }
-
-                if (confidence > bestConfidence) {
-                    bestCharset = charset;
-                    bestConfidence = confidence;
-                }
-            } catch (Exception e) {
-                //ignore; if this charset isn't supported by this platform, it's probably not correct anyway.
-            }
-        }
-
-        return bestCharset != null ? bestCharset : declared;
-    }
-
-    @Override
-    public String guessEncoding(InputStream is, String contentType) throws IOException {
-        Charset charset = contentTypeCharset(contentType);
-        Charset best = guessEncoding(is, charset);
-        return best == null ? null : best.name();
-    }
-
-    private static final Pattern contentTypeCharsetPattern =
-            Pattern.compile("(?i)\\bcharset\\s*=[\\s\"']*([^\\s,;\"']+)");
-
-    private static Charset contentTypeCharset(CharSequence contentType) {
-        if (contentType == null)
-            return null;
-        Matcher m = contentTypeCharsetPattern.matcher(contentType);
-        if (m.find()) {
-            try {
-                return CharsetUtils.forName(m.group(1));
-            } catch (Exception e) {
-                return null;
-            }
-        }
-        return null;
-    }
-
-    private static final Pattern xmlEncoding = Pattern.compile(
-            "(?is)\\A\\s*<\\?\\s*xml\\s+[^<>]*encoding\\s*=\\s*(?:['\"]\\s*)?([-_:.a-z0-9]+)");
 }

--- a/encoding/src/main/java/org/apache/any23/encoding/TikaEncodingDetector.java
+++ b/encoding/src/main/java/org/apache/any23/encoding/TikaEncodingDetector.java
@@ -114,7 +114,7 @@ public class TikaEncodingDetector implements EncodingDetector {
             while ((n = is.read(buffer)) != -1) {
                 chars.ensureCapacity(chars.length() + n);
                 for (int i = 0; i < n; i++) {
-                    chars.append((char) buffer[i]);
+                    chars.append((char)(buffer[i] & 0xFF));
                 }
             }
         } finally {

--- a/encoding/src/test/java/org/apache/any23/encoding/TikaEncodingDetectorTest.java
+++ b/encoding/src/test/java/org/apache/any23/encoding/TikaEncodingDetectorTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.Charset;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test case for {@link TikaEncodingDetector}.
@@ -89,8 +90,78 @@ public class TikaEncodingDetectorTest {
                 "\n <?Xml enCoding=Utf8?>"
         };
         for (String s : strings) {
-            Charset detected = TikaEncodingDetector.xmlCharset(s);
+            Charset detected = EncodingUtils.xmlCharset(s);
             assertEquals(detected, UTF_8);
+        }
+    }
+
+    @Test
+    public void testUTF8StateMachineForValid() throws IOException {
+        int state = 0;
+        for (int i = 0; i <= Character.MAX_CODE_POINT; i++) {
+            byte[] bytes = new String(Character.toChars(i)).getBytes(UTF_8);
+
+            for (byte b : bytes) {
+                state = EncodingUtils.nextStateUtf8(state, b);
+            }
+
+            assertEquals(new String(bytes, UTF_8).codePointAt(0), state);
+        }
+    }
+
+    @Test
+    public void testUTF8StateMachineForInvalid() {
+        for (int i = 0; i <= 0xFF; i++) { //check -1 state preservation
+            assertEquals(-1, EncodingUtils.nextStateUtf8(-1, (byte)i));
+        }
+
+        for (int i = 0x80; i < 0xC2; i++) { //check invalid first byte
+            assertEquals(-1, EncodingUtils.nextStateUtf8(0, (byte)i));
+        }
+
+        for (int i = 0xF5; i <= 0xFF; i++) { //illegal code points > 0x10FFFF
+            assertEquals(-1, EncodingUtils.nextStateUtf8(0, (byte)i));
+        }
+
+        for (int i = 0xC2; i <= 0xF4; i++) { //check invalid continuation bytes
+            //check invalid second byte
+            int state0 = EncodingUtils.nextStateUtf8(0, (byte)i);
+            assertTrue(state0 < -1);
+            int from = i == 0xE0 ? 0xA0 : i == 0xF0 ? 0x90 : 0x80;
+            for (int j = 0; j < from; j++) {
+                assertEquals(-1, EncodingUtils.nextStateUtf8(state0, (byte)j));
+            }
+            int to = i == 0xED ? 0xA0 : i == 0xF4 ? 0x90 : 0xC0;
+            for (int j = to; j <= 0xFF; j++) {
+                assertEquals(-1, EncodingUtils.nextStateUtf8(state0, (byte)j));
+            }
+            if (i >= 0xE0) { //check invalid third byte
+                int state1 = EncodingUtils.nextStateUtf8(state0, (byte) from);
+                assertTrue(state1 < -1);
+                for (int j = from + 1; j < to; j++) {
+                    assertTrue(EncodingUtils.nextStateUtf8(state0, (byte)j) < -1);
+                }
+                for (int j = 0; j < 0x80; j++) {
+                    assertEquals(-1, EncodingUtils.nextStateUtf8(state1, (byte) j));
+                }
+                for (int j = 0xC0; j <= 0xFF; j++) {
+                    assertEquals(-1, EncodingUtils.nextStateUtf8(state1, (byte) j));
+                }
+
+                if (i >= 0xF0) { //check invalid 4th byte
+                    int state2 = EncodingUtils.nextStateUtf8(state1, (byte) 0x80);
+                    assertTrue(state2 < -1);
+                    for (int j = 0x81; j < 0xC0; j++) {
+                        assertTrue(EncodingUtils.nextStateUtf8(state1, (byte)j) < -1);
+                    }
+                    for (int j = 0; j < 0x80; j++) {
+                        assertEquals(-1, EncodingUtils.nextStateUtf8(state2, (byte) j));
+                    }
+                    for (int j = 0xC0; j <= 0xFF; j++) {
+                        assertEquals(-1, EncodingUtils.nextStateUtf8(state2, (byte) j));
+                    }
+                }
+            }
         }
     }
 

--- a/encoding/src/test/java/org/apache/any23/encoding/TikaEncodingDetectorTest.java
+++ b/encoding/src/test/java/org/apache/any23/encoding/TikaEncodingDetectorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.any23.encoding;
 
+import org.apache.tika.detect.TextStatistics;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -90,7 +91,7 @@ public class TikaEncodingDetectorTest {
                 "\n <?Xml enCoding=Utf8?>"
         };
         for (String s : strings) {
-            Charset detected = EncodingUtils.xmlCharset(s);
+            Charset detected = EncodingUtils.xmlCharset(new TextStatistics(), s);
             assertEquals(detected, UTF_8);
         }
     }

--- a/encoding/src/test/java/org/apache/any23/encoding/TikaEncodingDetectorTest.java
+++ b/encoding/src/test/java/org/apache/any23/encoding/TikaEncodingDetectorTest.java
@@ -21,7 +21,6 @@ import org.apache.tika.detect.TextStatistics;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.rypt.f8.Utf8;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -31,7 +30,6 @@ import java.nio.charset.Charset;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test case for {@link TikaEncodingDetector}.
@@ -94,73 +92,6 @@ public class TikaEncodingDetectorTest {
         for (String s : strings) {
             Charset detected = EncodingUtils.xmlCharset(new TextStatistics(), s);
             assertEquals(detected, UTF_8);
-        }
-    }
-
-    @Test
-    public void testUTF8StateMachineForValid() throws IOException {
-        int state = 0;
-        for (int i = 0; i <= Character.MAX_CODE_POINT; i++) {
-            byte[] bytes = new String(Character.toChars(i)).getBytes(UTF_8);
-
-            for (byte b : bytes) {
-                state = Utf8.nextState(state, b);
-            }
-
-            assertEquals(new String(bytes, UTF_8).codePointAt(0), state);
-        }
-    }
-
-    @Test
-    public void testUTF8StateMachineForInvalid() {
-
-        for (int i = 0x80; i < 0xC2; i++) { //check invalid first byte
-            assertTrue(Utf8.isErrorState(Utf8.nextState(0, (byte)i)));
-        }
-
-        for (int i = 0xF5; i <= 0xFF; i++) { //illegal code points > 0x10FFFF
-            assertTrue(Utf8.isErrorState(Utf8.nextState(0, (byte)i)));
-        }
-
-        for (int i = 0xC2; i <= 0xF4; i++) { //check invalid continuation bytes
-            //check invalid second byte
-            int state0 = Utf8.nextState(0, (byte)i);
-            assertTrue(Utf8.isIncompleteState(state0));
-            int from = i == 0xE0 ? 0xA0 : i == 0xF0 ? 0x90 : 0x80;
-            for (int j = 0; j < from; j++) {
-                assertTrue(Utf8.isErrorState(Utf8.nextState(state0, (byte)j)));
-            }
-            int to = i == 0xED ? 0xA0 : i == 0xF4 ? 0x90 : 0xC0;
-            for (int j = to; j <= 0xFF; j++) {
-                assertTrue(Utf8.isErrorState(Utf8.nextState(state0, (byte)j)));
-            }
-            if (i >= 0xE0) { //check invalid third byte
-                int state1 = Utf8.nextState(state0, (byte) from);
-                assertTrue(Utf8.isIncompleteState(state1));
-                for (int j = from + 1; j < to; j++) {
-                    assertTrue(Utf8.isIncompleteState(Utf8.nextState(state0, (byte)j)));
-                }
-                for (int j = 0; j < 0x80; j++) {
-                    assertTrue(Utf8.isErrorState(Utf8.nextState(state1, (byte) j)));
-                }
-                for (int j = 0xC0; j <= 0xFF; j++) {
-                    assertTrue(Utf8.isErrorState(Utf8.nextState(state1, (byte) j)));
-                }
-
-                if (i >= 0xF0) { //check invalid 4th byte
-                    int state2 = Utf8.nextState(state1, (byte) 0x80);
-                    assertTrue(state2 < -1);
-                    for (int j = 0x81; j < 0xC0; j++) {
-                        assertTrue(Utf8.isIncompleteState(Utf8.nextState(state1, (byte)j)));
-                    }
-                    for (int j = 0; j < 0x80; j++) {
-                        assertTrue(Utf8.isErrorState(Utf8.nextState(state2, (byte) j)));
-                    }
-                    for (int j = 0xC0; j <= 0xFF; j++) {
-                        assertTrue(Utf8.isErrorState(Utf8.nextState(state2, (byte) j)));
-                    }
-                }
-            }
         }
     }
 

--- a/encoding/src/test/java/org/apache/any23/encoding/TikaEncodingDetectorTest.java
+++ b/encoding/src/test/java/org/apache/any23/encoding/TikaEncodingDetectorTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.any23.encoding;
 
-import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,7 +25,10 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test case for {@link TikaEncodingDetector}.
@@ -87,16 +89,44 @@ public class TikaEncodingDetectorTest {
                 "\n <?Xml enCoding=Utf8?>"
         };
         for (String s : strings) {
-            byte[] bytes = s.getBytes(StandardCharsets.US_ASCII);
-            Charset detected = TikaEncodingDetector.detectXmlEncoding(new ByteArrayInputStream(bytes), 256);
-            Assert.assertEquals(detected, StandardCharsets.UTF_8);
+            Charset detected = TikaEncodingDetector.xmlCharset(s);
+            assertEquals(detected, UTF_8);
         }
+    }
+
+    private static ByteArrayInputStream bytes(String string, Charset encoding) {
+        return new ByteArrayInputStream(string.getBytes(encoding));
+    }
+
+    @Test
+    public void testUtf8Simple() throws IOException {
+        assertEquals("UTF-8", detector.guessEncoding(bytes("Hellö Wörld!", UTF_8)));
+    }
+
+    @Test
+    public void testIso88591Simple() throws IOException {
+        assertEquals("ISO-8859-1", detector.guessEncoding(bytes("Hellö Wörld!", ISO_8859_1)));
+    }
+
+    @Test
+    public void testTikaIssue771() throws IOException {
+        assertEquals("UTF-8", detector.guessEncoding(bytes("Hello, World!", UTF_8)));
+    }
+
+    @Test
+    public void testTikaIssue868() throws IOException {
+        assertEquals("UTF-8", detector.guessEncoding(bytes("Indanyl", UTF_8)));
+    }
+
+    @Test
+    public void testTikaIssue2771() throws IOException {
+        assertEquals("UTF-8", detector.guessEncoding(bytes("Name: Amanda\nJazz Band", UTF_8)));
     }
 
     private void assertEncoding(final String expected, final String resource) throws IOException {
         try (InputStream fis = getClass().getResourceAsStream(resource)) {
             String encoding = detector.guessEncoding(fis);
-            Assert.assertEquals("Unexpected encoding", expected, encoding);
+            assertEquals("Unexpected encoding", expected, encoding);
         }
     }
 


### PR DESCRIPTION
Improves TikaEncodingDetector by:

1. Not second-guessing UTF-8 if there is *any* indication that a stream is UTF-8-encoded. We can't afford false positives from obscure, obsolete charsets such as IBM500 (See [TIKA-2771](https://issues.apache.org/jira/browse/TIKA-2771)).
2. Taking entire stream into account rather than a prefix (this shouldn't be a huge memory issue, as we are already holding the entire stream in memory to pass to each extractor, and extractors such as RDFa already parse the entire content into a DOM before generating the triples. If we want to make Any23 "streaming"-capable in the future to reduce memory requirements, we can look into that, but for now, since we're not, we may as well use that to our advantage to be more accurate in charset detection.)
3. Taking [TIKA-2771](https://issues.apache.org/jira/browse/TIKA-2771), [TIKA-2038](https://issues.apache.org/jira/browse/TIKA-2038), and [TIKA-539](https://issues.apache.org/jira/browse/TIKA-539) into account.