### PR TITLE
ANY23-427 http://semanticweb.org/ down causes tests to fail

### DIFF
--- a/service/src/test/java/org/apache/any23/servlet/ServletTest.java
+++ b/service/src/test/java/org/apache/any23/servlet/ServletTest.java
@@ -222,28 +222,24 @@ public class ServletTest {
     }
 
     /**
-     * This test has been disabled in order to avoid external resources
-     * dependencies
      *
      * @throws Exception if there is an error asserting test data
      */
     @Test
     public void testGETwithURLEncoding() throws Exception {
         content = null;
-        HttpTester.Response response = doGetRequest("/best/http://semanticweb.org/wiki/Knud_M%C3%B6ller");
+        HttpTester.Response response = doGetRequest("/best/http://dbpedia.org/resource/Knud_M%C3%B6ller");
         Assert.assertEquals(200, response.getStatus());
     }
 
     /**
-     * This test has been disabled in order to avoid external resources
-     * dependencies
      *
      * @throws Exception if there is an error asserting test data
      */
     @Test
     public void testGETwithURLEncodingWithQuery() throws Exception {
         content = null;
-        HttpTester.Response response = doGetRequest("/best/http://semanticweb.org/wiki/Knud_M%C3%B6ller?appo=xxx");
+        HttpTester.Response response = doGetRequest("/best/http://commons.wikimedia.org/wiki/Special:FilePath/Knud_M%C3%B6ller_vuonna_1965.jpg?width=300");
         Assert.assertEquals(200, response.getStatus());
     }
 
@@ -256,7 +252,7 @@ public class ServletTest {
     @Test
     public void testGETwithURLEncodingWithFragment() throws Exception {
         content = null;
-        HttpTester.Response response = doGetRequest("/best/http://semanticweb.org/wiki/Knud_M%C3%B6ller#abcde");
+        HttpTester.Response response = doGetRequest("/best/http://dbpedia.org/resource/Knud_M%C3%B6ller#title");
         Assert.assertEquals(200, response.getStatus());
     }
 

--- a/service/src/test/java/org/apache/any23/servlet/ServletTest.java
+++ b/service/src/test/java/org/apache/any23/servlet/ServletTest.java
@@ -239,7 +239,7 @@ public class ServletTest {
     @Test
     public void testGETwithURLEncodingWithQuery() throws Exception {
         content = null;
-        HttpTester.Response response = doGetRequest("/best/http://commons.wikimedia.org/wiki/Special:FilePath/Knud_M%C3%B6ller_vuonna_1965.jpg?width=300");
+        HttpTester.Response response = doGetRequest("/best/https://en.wikipedia.org/wiki/Knud_M%C3%B6ller?oldid=717712065");
         Assert.assertEquals(200, response.getStatus());
     }
 


### PR DESCRIPTION
This issue addresses https://issues.apache.org/jira/browse/ANY23-427 and also stabilizes tests. 