### PR TITLE
ANY23-441 Upgrade JSoup version from 1.11.3 to 1.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,7 +372,7 @@
       <dependency>
         <groupId>org.jsoup</groupId>
         <artifactId>jsoup</artifactId>
-        <version>1.11.3</version>
+        <version>1.12.1</version>
       </dependency>
       <dependency>
         <groupId>net.sf.biweekly</groupId>


### PR DESCRIPTION
This ugprade fixes the ArrayOutOfBoundException described in [ANY23-441](https://issues.apache.org/jira/projects/ANY23/issues/ANY23-441).

I did not add a test because I failed to found a minimal reproduction case.