### PR TITLE
ANY23-443 improve speed & stability of RDFa extractors

### DIFF
--- a/core/src/main/java/org/apache/any23/extractor/rdf/BaseRDFExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/BaseRDFExtractor.java
@@ -120,7 +120,7 @@ public abstract class BaseRDFExtractor implements Extractor.ContentExtractor {
         }
     }
 
-    private static String toString(Throwable th) {
+    protected static String toString(Throwable th) {
         StringWriter writer = new StringWriter();
         try (PrintWriter pw = new PrintWriter(writer)) {
             th.printStackTrace(pw);

--- a/core/src/main/java/org/apache/any23/extractor/rdf/BaseRDFExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/BaseRDFExtractor.java
@@ -120,7 +120,9 @@ public abstract class BaseRDFExtractor implements Extractor.ContentExtractor {
         }
     }
 
-    protected static String toString(Throwable th) {
+    // keep private to avoid backwards compatibility woes (may move around later)
+    @SuppressWarnings("Duplicates")
+    private static String toString(Throwable th) {
         StringWriter writer = new StringWriter();
         try (PrintWriter pw = new PrintWriter(writer)) {
             th.printStackTrace(pw);

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/BaseRDFaExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/BaseRDFaExtractor.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.any23.extractor.rdfa;
 
 import org.apache.any23.extractor.ExtractionContext;
@@ -20,7 +37,12 @@ import org.semarglproject.source.StreamProcessor;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
+/**
+ * @author Hans Brende (hansbrende@apache.org)
+ */
 abstract class BaseRDFaExtractor extends BaseRDFExtractor {
 
     private final short version;
@@ -56,4 +78,18 @@ abstract class BaseRDFaExtractor extends BaseRDFExtractor {
             extractionResult.notifyIssue(IssueReport.IssueLevel.FATAL, toString(e), -1, -1);
         }
     }
+
+    @SuppressWarnings("Duplicates")
+    private static String toString(Throwable th) {
+        StringWriter writer = new StringWriter();
+        try (PrintWriter pw = new PrintWriter(writer)) {
+            th.printStackTrace(pw);
+        }
+        String string = writer.toString();
+        if (string.length() > 1024) {
+            return string.substring(0, 1021) + "...";
+        }
+        return string;
+    }
+
 }

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/BaseRDFaExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/BaseRDFaExtractor.java
@@ -4,143 +4,56 @@ import org.apache.any23.extractor.ExtractionContext;
 import org.apache.any23.extractor.ExtractionException;
 import org.apache.any23.extractor.ExtractionParameters;
 import org.apache.any23.extractor.ExtractionResult;
-import org.apache.any23.extractor.html.JsoupUtils;
+import org.apache.any23.extractor.IssueReport;
 import org.apache.any23.extractor.rdf.BaseRDFExtractor;
-import org.eclipse.rdf4j.common.net.ParsedIRI;
-import org.jsoup.nodes.Attribute;
-import org.jsoup.nodes.Comment;
-import org.jsoup.nodes.DataNode;
+import org.apache.any23.rdf.Any23ValueFactoryWrapper;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.helpers.RDFaParserSettings;
+import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.DocumentType;
-import org.jsoup.nodes.Element;
-import org.jsoup.nodes.Entities;
-import org.jsoup.nodes.Node;
-import org.jsoup.select.NodeFilter;
-import org.jsoup.select.NodeTraversor;
+import org.jsoup.parser.ParseSettings;
+import org.jsoup.parser.Parser;
+import org.semarglproject.rdf.rdfa.RdfaParser;
+import org.semarglproject.rdf4j.rdf.rdfa.SemarglParserSettings;
+import org.semarglproject.sink.XmlSink;
+import org.semarglproject.source.StreamProcessor;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.regex.Pattern;
 
 abstract class BaseRDFaExtractor extends BaseRDFExtractor {
 
+    private final short version;
 
-    private static final Pattern invalidXMLCharacters = Pattern.compile(
-            "[^\u0009\r\n\u0020-\uD7FF\uE000-\uFFFD\ud800\udc00-\udbff\udfff]");
-
-    private static final Charset charset = StandardCharsets.UTF_8;
-
-    BaseRDFaExtractor(boolean verifyDataType, boolean stopAtFirstError) {
-        super(verifyDataType, stopAtFirstError);
+    BaseRDFaExtractor(short version) {
+        super(false, false);
+        this.version = version;
     }
 
     @Override
     public void run(ExtractionParameters extractionParameters, ExtractionContext extractionContext, InputStream in, ExtractionResult extractionResult) throws IOException, ExtractionException {
 
-        String iri = extractionContext.getDocumentIRI().stringValue();
+        SemarglSink rdfaSink = new SemarglSink(extractionResult, new Any23ValueFactoryWrapper(
+                SimpleValueFactory.getInstance(),
+                extractionResult,
+                extractionContext.getDefaultLanguage()
+        ));
 
-        Document doc = JsoupUtils.parse(in, iri, null);
-        doc.outputSettings()
-                .prettyPrint(false)
-                .syntax(Document.OutputSettings.Syntax.xml)
-                .escapeMode(Entities.EscapeMode.xhtml)
-                .charset(charset);
-        // Delete scripts, comments, and doctypes
-        // See https://issues.apache.org/jira/browse/ANY23-317
-        // and https://issues.apache.org/jira/browse/ANY23-340
-        NodeTraversor.filter(new NodeFilter() {
-            final HashSet<String> tmpAttributeKeys = new HashSet<>();
+        XmlSink xmlSink = RdfaParser.connect(rdfaSink);
+        xmlSink.setProperty(StreamProcessor.PROCESSOR_GRAPH_HANDLER_PROPERTY, rdfaSink);
+        xmlSink.setProperty(RdfaParser.RDFA_VERSION_PROPERTY, version);
+        xmlSink.setProperty(RdfaParser.ENABLE_VOCAB_EXPANSION, RDFaParserSettings.VOCAB_EXPANSION_ENABLED.getDefaultValue());
+        xmlSink.setProperty(RdfaParser.ENABLE_PROCESSOR_GRAPH, SemarglParserSettings.PROCESSOR_GRAPH_ENABLED.getDefaultValue());
 
-            @Override
-            public FilterResult head(Node node, int depth) {
-                if (node instanceof Element) {
-                    HashSet<String> attributeKeys = tmpAttributeKeys;
-                    for (Iterator<Attribute> it = node.attributes().iterator(); it.hasNext(); ) {
-                        // fix for ANY23-350: valid xml attribute names are ^[a-zA-Z_:][-a-zA-Z0-9_:.]
-                        Attribute attr = it.next();
-                        String oldKey = attr.getKey();
-                        String newKey = oldKey.replaceAll("[^-a-zA-Z0-9_:.]", "");
-
-                        // fix for ANY23-347: strip non-reserved xml namespaces
-                        // See https://www.w3.org/TR/xml-names/#sec-namespaces
-                        // "All other prefixes beginning with the three-letter sequence x, m, l,
-                        // in any case combination, are reserved. This means that:
-                        //   * users SHOULD NOT use them except as defined by later specifications
-                        //   * processors MUST NOT treat them as fatal errors."
-                        int prefixlen = newKey.lastIndexOf(':') + 1;
-                        String prefix = newKey.substring(0, prefixlen).toLowerCase();
-                        newKey = (prefix.startsWith("xml") ? prefix : "") + newKey.substring(prefixlen);
-
-                        if (newKey.matches("[a-zA-Z_:][-a-zA-Z0-9_:.]*")
-                                //the namespace name for "xmlns" MUST NOT be declared
-                                //the namespace name for "xml" need not be declared
-                                && !newKey.startsWith("xmlns:xml")
-                                // fix for ANY23-380: disallow duplicate attribute keys
-                                && attributeKeys.add(newKey)) {
-                            //avoid indexOf() operation if possible
-                            if (!newKey.equals(oldKey)) {
-                                attr.setKey(newKey);
-                            }
-                        } else {
-                            it.remove();
-                        }
-                    }
-                    attributeKeys.clear();
-
-                    String tagName = ((Element)node).tagName().replaceAll("[^-a-zA-Z0-9_:.]", "");
-                    tagName = tagName.substring(tagName.lastIndexOf(':') + 1);
-                    ((Element)node).tagName(tagName.matches("[a-zA-Z_:][-a-zA-Z0-9_:.]*") ? tagName : "div");
-
-                    // fix for ANY23-389
-                    resolve_base:
-                    if ("base".equalsIgnoreCase(tagName) && node.hasAttr("href")) {
-                        String href = node.attr("href");
-                        String absHref;
-                        try {
-                            ParsedIRI parsedHref = ParsedIRI.create(href.trim());
-                            if (parsedHref.isAbsolute()) {
-                                absHref = parsedHref.toString();
-                            } else {
-                                parsedHref = ParsedIRI.create(iri.trim()).resolve(parsedHref);
-                                if (parsedHref.isAbsolute()) {
-                                    absHref = parsedHref.toString();
-                                } else {
-                                    // shouldn't happen unless document IRI wasn't absolute
-                                    // ignore and let underlying RDFa parser report the issue
-                                    break resolve_base;
-                                }
-                            }
-                        } catch (RuntimeException e) {
-                            // can't parse href as a relative or absolute IRI:
-                            // ignore and let underlying RDFa parser report the issue
-                            break resolve_base;
-                        }
-                        if (!absHref.equals(href)) {
-                            node.attr("href", absHref);
-                        }
-                    }
-
-                    return FilterResult.CONTINUE;
-                }
-                return node instanceof DataNode || node instanceof Comment || node instanceof DocumentType
-                        ? FilterResult.REMOVE : FilterResult.CONTINUE;
-            }
-            @Override
-            public FilterResult tail(Node node, int depth) {
-                return FilterResult.CONTINUE;
-            }
-        }, doc);
-
-        // fix for ANY23-379: remove invalid xml characters from document
-        String finalOutput = invalidXMLCharacters.matcher(doc.toString()).replaceAll("");
-
-        in = new ByteArrayInputStream(finalOutput.getBytes(charset));
-
-        super.run(extractionParameters, extractionContext, in, extractionResult);
+        String baseUri = extractionContext.getDocumentIRI().stringValue();
+        xmlSink.setBaseUri(baseUri);
+        Document doc = Jsoup.parse(in, null, baseUri, Parser.htmlParser().settings(ParseSettings.preserveCase));
+        try {
+            xmlSink.startDocument();
+            doc.traverse(new JsoupScanner(xmlSink));
+            xmlSink.endDocument();
+        } catch (Exception e) {
+            extractionResult.notifyIssue(IssueReport.IssueLevel.FATAL, toString(e), -1, -1);
+        }
     }
 }

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/JsoupScanner.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/JsoupScanner.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.any23.extractor.rdfa;
 
 import org.jsoup.nodes.CDataNode;
@@ -13,6 +30,9 @@ import org.xml.sax.helpers.NamespaceSupport;
 
 import java.util.ArrayList;
 
+/**
+ * @author Hans Brende (hansbrende@apache.org)
+ */
 class JsoupScanner implements NodeVisitor {
 
     private final NamespaceSupport ns = new NamespaceSupport();
@@ -28,10 +48,6 @@ class JsoupScanner implements NodeVisitor {
     private static String orEmpty(String str) {
         return str == null ? "" : str;
     }
-
-//    private static String orNull(String str) {
-//        return "".equals(str) ? null : str;
-//    }
 
     private void startElement(Element e) throws SAXException {
         ns.pushContext();
@@ -111,7 +127,6 @@ class JsoupScanner implements NodeVisitor {
         handler.comment(str.toCharArray(), 0, str.length());
     }
 
-
     @Override
     public void head(Node node, int depth) {
         try {
@@ -141,6 +156,7 @@ class JsoupScanner implements NodeVisitor {
                 endElement((Element) node);
             } else if (node instanceof CDataNode) {
                 handler.endCDATA();
+                // TODO support document types
 //            } else if (node instanceof DocumentType) {
 //                handler.endDTD();
             }
@@ -149,11 +165,8 @@ class JsoupScanner implements NodeVisitor {
         }
     }
 
-
-
     @SuppressWarnings("unchecked")
     private static <E extends Throwable> void sneakyThrow(Throwable e) throws E {
         throw (E)e;
     }
-
 }

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/JsoupScanner.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/JsoupScanner.java
@@ -1,0 +1,159 @@
+package org.apache.any23.extractor.rdfa;
+
+import org.jsoup.nodes.CDataNode;
+import org.jsoup.nodes.Comment;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+import org.jsoup.select.NodeVisitor;
+import org.semarglproject.sink.XmlSink;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+import org.xml.sax.helpers.NamespaceSupport;
+
+import java.util.ArrayList;
+
+class JsoupScanner implements NodeVisitor {
+
+    private final NamespaceSupport ns = new NamespaceSupport();
+    private final AttributesImpl attrs = new AttributesImpl();
+    private final String[] nameParts = new String[3];
+
+    private final XmlSink handler;
+
+    JsoupScanner(XmlSink handler) {
+        this.handler = handler;
+    }
+
+    private static String orEmpty(String str) {
+        return str == null ? "" : str;
+    }
+
+//    private static String orNull(String str) {
+//        return "".equals(str) ? null : str;
+//    }
+
+    private void startElement(Element e) throws SAXException {
+        ns.pushContext();
+
+        attrs.clear();
+        final ArrayList<String> remainingAttrs = new ArrayList<>();
+        for (org.jsoup.nodes.Attribute attr : e.attributes()) {
+            String name = attr.getKey();
+            String value = attr.getValue();
+            if (name.startsWith("xmlns")) {
+                if (name.length() == 5) {
+                    ns.declarePrefix("", value);
+                    handler.startPrefixMapping("", value);
+                    continue;
+                } else if (name.charAt(5) == ':') {
+                    String localName = name.substring(6);
+                    ns.declarePrefix(localName, value);
+                    handler.startPrefixMapping(localName, value);
+                    continue;
+                }
+            }
+
+            remainingAttrs.add(name);
+            remainingAttrs.add(value);
+        }
+
+        for (int i = 0, len = remainingAttrs.size(); i < len; i += 2) {
+            String name = remainingAttrs.get(i);
+            String value = remainingAttrs.get(i + 1);
+            String[] parts = ns.processName(name, nameParts, true);
+            if (parts != null) {
+                attrs.addAttribute(orEmpty(parts[0]), orEmpty(parts[1]), parts[2], "CDATA", value);
+            }
+        }
+
+        String qName = e.tagName();
+
+        String[] parts = ns.processName(qName, nameParts, false);
+        if (parts == null) {
+            handler.startElement("", "", qName, attrs);
+        } else {
+            handler.startElement(orEmpty(parts[0]), orEmpty(parts[1]), parts[2], attrs);
+        }
+
+    }
+
+    private void endElement(Element e) throws SAXException {
+
+        String qName = e.tagName();
+        String[] parts = ns.processName(qName, nameParts, false);
+        if (parts == null) {
+            handler.endElement("", "", qName);
+        } else {
+            handler.endElement(orEmpty(parts[0]), orEmpty(parts[1]), parts[2]);
+        }
+
+        for (org.jsoup.nodes.Attribute attr : e.attributes()) {
+            String name = attr.getKey();
+            if (name.startsWith("xmlns")) {
+                if (name.length() == 5) {
+                    handler.endPrefixMapping("");
+                } else if (name.charAt(5) == ':') {
+                    String localName = name.substring(6);
+                    handler.endPrefixMapping(localName);
+                }
+            }
+        }
+
+        ns.popContext();
+    }
+
+    private void handleText(String str) throws SAXException {
+        handler.characters(str.toCharArray(), 0, str.length());
+    }
+
+    private void handleComment(String str) throws SAXException {
+        handler.comment(str.toCharArray(), 0, str.length());
+    }
+
+
+    @Override
+    public void head(Node node, int depth) {
+        try {
+            if (node instanceof Element) {
+                startElement((Element) node);
+            } else if (node instanceof CDataNode) {
+                handler.startCDATA();
+                handleText(((CDataNode) node).text());
+            } else if (node instanceof TextNode) {
+                handleText(((TextNode) node).text());
+                // TODO support document types
+//            } else if (node instanceof DocumentType) {
+//                DocumentType dt = (DocumentType)node;
+//                handler.startDTD(dt.attr("name"), orNull(dt.attr("publicId")), orNull(dt.attr("systemId")));
+            } else if (node instanceof Comment) {
+                handleComment(((Comment) node).getData());
+            }
+        } catch (SAXException e) {
+            sneakyThrow(e);
+        }
+    }
+
+    @Override
+    public void tail(Node node, int depth) {
+        try {
+            if (node instanceof Element) {
+                endElement((Element) node);
+            } else if (node instanceof CDataNode) {
+                handler.endCDATA();
+//            } else if (node instanceof DocumentType) {
+//                handler.endDTD();
+            }
+        } catch (SAXException e) {
+            sneakyThrow(e);
+        }
+    }
+
+
+
+    @SuppressWarnings("unchecked")
+    private static <E extends Throwable> void sneakyThrow(Throwable e) throws E {
+        throw (E)e;
+    }
+
+}

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/RDFa11Extractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/RDFa11Extractor.java
@@ -22,6 +22,7 @@ import org.apache.any23.extractor.ExtractionResult;
 import org.apache.any23.extractor.ExtractorDescription;
 import org.apache.any23.extractor.rdf.RDFParserFactory;
 import org.eclipse.rdf4j.rio.RDFParser;
+import org.semarglproject.vocab.RDFa;
 
 /**
  * {@link org.apache.any23.extractor.Extractor} implementation for
@@ -31,12 +32,13 @@ import org.eclipse.rdf4j.rio.RDFParser;
  */
 public class RDFa11Extractor extends BaseRDFaExtractor {
 
+    @Deprecated
     public RDFa11Extractor(boolean verifyDataType, boolean stopAtFirstError) {
-        super(verifyDataType, stopAtFirstError);
+        this();
     }
 
     public RDFa11Extractor() {
-        this(false, false);
+        super(RDFa.VERSION_11);
     }
 
     @Override
@@ -45,6 +47,7 @@ public class RDFa11Extractor extends BaseRDFaExtractor {
     }
 
     @Override
+    @Deprecated
     protected RDFParser getParser(ExtractionContext extractionContext, ExtractionResult extractionResult) {
         return RDFParserFactory.getInstance().getRDFa11Parser(
                 isVerifyDataType(), isStopAtFirstError(), extractionContext, extractionResult

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/RDFa11Extractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/RDFa11Extractor.java
@@ -29,12 +29,38 @@ import org.semarglproject.vocab.RDFa;
  * <a href="http://www.w3.org/TR/rdfa-core/">RDFa 1.1</a> specification.
  *
  * @author Michele Mostarda (mostarda@fbk.eu)
+ * @author Hans Brende (hansbrende@apache.org)
  */
 public class RDFa11Extractor extends BaseRDFaExtractor {
 
+    /**
+     * @deprecated since 2.4. This extractor has never supported these settings. Use {@link #RDFa11Extractor()} instead.
+     * @param verifyDataType has no effect
+     * @param stopAtFirstError has no effect
+     */
     @Deprecated
     public RDFa11Extractor(boolean verifyDataType, boolean stopAtFirstError) {
         this();
+    }
+
+    /**
+     * @deprecated since 2.4. This extractor has never supported this setting. Do not use.
+     * @param stopAtFirstError has no effect
+     */
+    @Deprecated
+    @Override
+    public void setStopAtFirstError(boolean stopAtFirstError) {
+        super.setStopAtFirstError(stopAtFirstError);
+    }
+
+    /**
+     * @deprecated since 2.4. This extractor has never supported this setting. Do not use.
+     * @param verifyDataType has no effect
+     */
+    @Deprecated
+    @Override
+    public void setVerifyDataType(boolean verifyDataType) {
+        super.setVerifyDataType(verifyDataType);
     }
 
     public RDFa11Extractor() {
@@ -46,6 +72,12 @@ public class RDFa11Extractor extends BaseRDFaExtractor {
         return RDFa11ExtractorFactory.getDescriptionInstance();
     }
 
+    /**
+     * @deprecated since 2.4. This extractor no longer wraps an RDF4J {@link RDFParser}. Do not use this method.
+     * @param extractionContext the extraction context
+     * @param extractionResult the extraction result
+     * @return a {@link RDFParser}
+     */
     @Override
     @Deprecated
     protected RDFParser getParser(ExtractionContext extractionContext, ExtractionResult extractionResult) {

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/RDFaExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/RDFaExtractor.java
@@ -29,12 +29,38 @@ import org.semarglproject.vocab.RDFa;
  * <a href="http://www.w3.org/TR/rdfa-syntax/">RDFa 1.0</a> specification.
  *
  * @author Michele Mostarda (mostarda@fbk.eu)
+ * @author Hans Brende (hansbrende@apache.org)
  */
 public class RDFaExtractor extends BaseRDFaExtractor {
 
+    /**
+     * @deprecated since 2.4. This extractor has never supported these settings. Use {@link #RDFaExtractor()} instead.
+     * @param verifyDataType has no effect
+     * @param stopAtFirstError has no effect
+     */
     @Deprecated
     public RDFaExtractor(boolean verifyDataType, boolean stopAtFirstError) {
         this();
+    }
+
+    /**
+     * @deprecated since 2.4. This extractor has never supported this setting. Do not use.
+     * @param stopAtFirstError has no effect
+     */
+    @Deprecated
+    @Override
+    public void setStopAtFirstError(boolean stopAtFirstError) {
+        super.setStopAtFirstError(stopAtFirstError);
+    }
+
+    /**
+     * @deprecated since 2.4. This extractor has never supported this setting. Do not use.
+     * @param verifyDataType has no effect
+     */
+    @Deprecated
+    @Override
+    public void setVerifyDataType(boolean verifyDataType) {
+        super.setVerifyDataType(verifyDataType);
     }
 
     public RDFaExtractor() {
@@ -46,6 +72,12 @@ public class RDFaExtractor extends BaseRDFaExtractor {
         return RDFaExtractorFactory.getDescriptionInstance();
     }
 
+    /**
+     * @deprecated since 2.4. This extractor no longer wraps an RDF4J {@link RDFParser}. Do not use this method.
+     * @param extractionContext the extraction context
+     * @param extractionResult the extraction result
+     * @return a {@link RDFParser}
+     */
     @Override
     @Deprecated
     protected RDFParser getParser(ExtractionContext extractionContext, ExtractionResult extractionResult) {

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/RDFaExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/RDFaExtractor.java
@@ -22,6 +22,7 @@ import org.apache.any23.extractor.ExtractionResult;
 import org.apache.any23.extractor.ExtractorDescription;
 import org.apache.any23.extractor.rdf.RDFParserFactory;
 import org.eclipse.rdf4j.rio.RDFParser;
+import org.semarglproject.vocab.RDFa;
 
 /**
  * {@link org.apache.any23.extractor.Extractor} implementation for
@@ -31,12 +32,13 @@ import org.eclipse.rdf4j.rio.RDFParser;
  */
 public class RDFaExtractor extends BaseRDFaExtractor {
 
+    @Deprecated
     public RDFaExtractor(boolean verifyDataType, boolean stopAtFirstError) {
-        super(verifyDataType, stopAtFirstError);
+        this();
     }
 
     public RDFaExtractor() {
-        this(false, false);
+        super(RDFa.VERSION_10);
     }
 
     @Override
@@ -45,6 +47,7 @@ public class RDFaExtractor extends BaseRDFaExtractor {
     }
 
     @Override
+    @Deprecated
     protected RDFParser getParser(ExtractionContext extractionContext, ExtractionResult extractionResult) {
         return RDFParserFactory.getInstance().getRDFa10Parser(
                 isVerifyDataType(), isStopAtFirstError(), extractionContext, extractionResult

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/SemarglSink.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/SemarglSink.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.any23.extractor.rdfa;
 
 import org.apache.any23.extractor.ExtractionResult;
@@ -6,6 +23,9 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 
+/**
+ * @author Hans Brende (hansbrende@apache.org)
+ */
 final class SemarglSink implements org.semarglproject.sink.TripleSink, org.semarglproject.rdf.ProcessorGraphHandler {
 
     private static final String BNODE_PREFIX = org.semarglproject.vocab.RDF.BNODE_PREFIX;

--- a/core/src/main/java/org/apache/any23/extractor/rdfa/SemarglSink.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdfa/SemarglSink.java
@@ -1,0 +1,79 @@
+package org.apache.any23.extractor.rdfa;
+
+import org.apache.any23.extractor.ExtractionResult;
+import org.apache.any23.extractor.IssueReport;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+
+final class SemarglSink implements org.semarglproject.sink.TripleSink, org.semarglproject.rdf.ProcessorGraphHandler {
+
+    private static final String BNODE_PREFIX = org.semarglproject.vocab.RDF.BNODE_PREFIX;
+
+    private final ExtractionResult handler;
+    private final ValueFactory valueFactory;
+
+    SemarglSink(ExtractionResult handler, ValueFactory valueFactory) {
+        this.handler = handler;
+        this.valueFactory = valueFactory;
+    }
+
+    private Resource createResource(String arg) {
+        if (arg.startsWith(BNODE_PREFIX)) {
+            return valueFactory.createBNode(arg.substring(BNODE_PREFIX.length()));
+        }
+        return valueFactory.createIRI(arg);
+    }
+
+    private void writeTriple(String s, String p, Value o) {
+        handler.writeTriple(createResource(s), valueFactory.createIRI(p), o);
+    }
+
+    @Override
+    public final void addNonLiteral(String s, String p, String o) {
+        writeTriple(s, p, createResource(o));
+    }
+
+    @Override
+    public final void addPlainLiteral(String s, String p, String o, String lang) {
+        writeTriple(s, p, lang == null ? valueFactory.createLiteral(o) : valueFactory.createLiteral(o, lang));
+    }
+
+    @Override
+    public final void addTypedLiteral(String s, String p, String o, String type) {
+        writeTriple(s, p, valueFactory.createLiteral(o, valueFactory.createIRI(type)));
+    }
+
+    @Override
+    public void startStream() {
+
+    }
+
+    @Override
+    public void endStream() {
+    }
+
+    @Override
+    public boolean setProperty(String key, Object value) {
+        return false;
+    }
+
+    @Override
+    public void setBaseUri(String baseUri) {
+    }
+
+    @Override
+    public void info(String infoClass, String message) {
+
+    }
+
+    @Override
+    public void warning(String warningClass, String message) {
+        handler.notifyIssue(IssueReport.IssueLevel.WARNING, message, -1, -1);
+    }
+
+    @Override
+    public void error(String errorClass, String message) {
+        handler.notifyIssue(IssueReport.IssueLevel.ERROR, message, -1, -1);
+    }
+}

--- a/core/src/test/java/org/apache/any23/extractor/rdfa/RDFa11ExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/rdfa/RDFa11ExtractorTest.java
@@ -94,6 +94,7 @@ public class RDFa11ExtractorTest extends AbstractRDFaExtractorTestCase {
     public void testBasicWithSyntaxErrors() {
         //test issues ANY23-347 and ANY23-350
         assertExtract("/html/rdfa/basic-with-errors.html");
+        System.out.println(dumpModelToTurtle());
         assertContains(null, vDCTERMS.creator, RDFUtils.literal("Alice", "en"));
         assertContains(null, vDCTERMS.title,
                 RDFUtils.literal("The trouble with Bob", "en"));

--- a/core/src/test/java/org/apache/any23/extractor/rdfa/RDFa11ExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/rdfa/RDFa11ExtractorTest.java
@@ -94,7 +94,6 @@ public class RDFa11ExtractorTest extends AbstractRDFaExtractorTestCase {
     public void testBasicWithSyntaxErrors() {
         //test issues ANY23-347 and ANY23-350
         assertExtract("/html/rdfa/basic-with-errors.html");
-        System.out.println(dumpModelToTurtle());
         assertContains(null, vDCTERMS.creator, RDFUtils.literal("Alice", "en"));
         assertContains(null, vDCTERMS.title,
                 RDFUtils.literal("The trouble with Bob", "en"));


### PR DESCRIPTION
I've implemented the performance (and stability) improvements I suggested in [ANY23-443](https://issues.apache.org/jira/browse/ANY23-443) by getting rid of all the RDFa middlemen: 

Any23 → Jsoup → ~InputStream~ → ~RDF4J~ → ~XMLReader~ → RdfaParser → ~RDF4J~ → Any23

All tests pass.