### PR TITLE
ANY23-440 any23 configuration documentation has a wrong property name

### DIFF
--- a/src/site/apt/configuration.apt
+++ b/src/site/apt/configuration.apt
@@ -113,7 +113,7 @@ any23.extract(extractionParameters, "http://path/to/doc", tripleHandler);
 *-------------------------------------------+-------------------------------+------------------------------------------------------------------------------------+
 |any23.extraction.rdfa.programmatic         |on (possible values: on/off)   |Switches between the programmatic RDFa 1.1 Extractor and the RDFa 1.0 XSLT base one.|                                                                                    |
 *-------------------------------------------+-------------------------------+------------------------------------------------------------------------------------+
-|any23.extraction.context.uri               |?(means current document IRI)  |Default value for extraction content IRI.                                           |
+|any23.extraction.context.iri               |?(means current document IRI)  |Default value for extraction content IRI.                                           |
 *-------------------------------------------+-------------------------------+------------------------------------------------------------------------------------+
 |any23.plugin.dirs                          |./plugins                      |Directory containing Apache Any23 plugins.                                                 |
 *-------------------------------------------+-------------------------------+------------------------------------------------------------------------------------+


### PR DESCRIPTION
This PR addresses https://issues.apache.org/jira/browse/ANY23-440