### PR TITLE
ANY23-458 Improve extractor and writer information in Rover

### DIFF
--- a/cli/src/main/java/org/apache/any23/cli/Rover.java
+++ b/cli/src/main/java/org/apache/any23/cli/Rover.java
@@ -29,6 +29,10 @@ import org.apache.any23.configuration.Setting;
 import org.apache.any23.configuration.Settings;
 import org.apache.any23.extractor.ExtractionParameters;
 import org.apache.any23.extractor.ExtractionParameters.ValidationMode;
+import org.apache.any23.extractor.ExtractorFactory;
+import org.apache.any23.extractor.ExtractorGroup;
+import org.apache.any23.extractor.ExtractorRegistry;
+import org.apache.any23.extractor.ExtractorRegistryImpl;
 import org.apache.any23.filter.IgnoreAccidentalRDFa;
 import org.apache.any23.filter.IgnoreTitlesOfEmptyDocuments;
 import org.apache.any23.source.DocumentSource;
@@ -73,11 +77,12 @@ import static java.lang.String.format;
  * @author Gabriele Renzi
  * @author Hans Brende (hansbrende@apache.org)
  */
-@Parameters(commandNames = { "rover" }, commandDescription = "Any23 Command Line Tool.")
+@Parameters(commandNames = { "rover" }, commandDescription = "Apache Any23 Command Line Tool.")
 public class Rover extends BaseTool {
 
     private static final Logger logger = LoggerFactory.getLogger(Rover.class);
 
+    private static final ExtractorRegistry eRegistry = ExtractorRegistryImpl.getInstance();
     private static final WriterFactoryRegistry registry = WriterFactoryRegistry.getInstance();
     private static final String DEFAULT_WRITER_IDENTIFIER = NTriplesWriterFactory.IDENTIFIER;
 
@@ -112,12 +117,16 @@ public class Rover extends BaseTool {
     @Parameter(description = "input IRIs {<url>|<file>}+", converter = ArgumentToIRIConverter.class)
     protected List<String> inputIRIs = new LinkedList<>();
 
-    @Parameter(names = { "-e",
-            "--extractors" }, description = "a comma-separated list of extractors, e.g. rdf-xml,rdf-turtle")
-    private List<String> extractors = new LinkedList<>();
+    @Parameter(names = { "-e", "--extractors" }, description = "a comma-separated list of extractors, "
+            + "e.g. rdf-xml,rdf-turtle, etc. A complete extractor list can be obtained by calling ./any23 extractor --list")
+    private List<String> extractors = new LinkedList<String>() {
+        {
+            addAll(eRegistry.getAllNames());
+        }
+    };
 
     @Parameter(names = { "-f",
-            "--format" }, description = "a comma-separated list of writer factories, e.g. notrivial,nquads")
+            "--format" }, description = "a comma-separated list of writer factories, e.g. json,jsonld,nquads,notrivial,ntriples,trix,turtle,uri")
     private List<String> formats = new LinkedList<String>() {
         {
             add(DEFAULT_WRITER_IDENTIFIER);


### PR DESCRIPTION
This PR addresses https://issues.apache.org/jira/browse/ANY23-458

PR address the following improved info to STDOUT. Note the improved info specifically for `--extractors` and `--format` flags.

```
    rover      Apache Any23 Command Line Tool.
      Usage: rover [options] input IRIs {<url>|<file>}+
        Options:
          -d, --defaultns
            Override the default namespace used to produce statements.
          -e, --extractors
            a comma-separated list of extractors, e.g. rdf-xml,rdf-turtle,
            etc. A complete extractor list can be obtained by calling ./any23
            extractor --list
            Default: [csv, html-embedded-jsonld, html-head-icbm, html-head-links, html-head-meta, html-head-title, html-mf-adr, html-mf-geo, html-mf-hcalendar, html-mf-hcard, html-mf-hlisting, html-mf-hrecipe, html-mf-hresume, html-mf-hreview, html-mf-hreview-aggregate, html-mf-license, html-mf-species, html-mf-xfn, html-microdata, html-rdfa11, html-xpath, ical, jcal, owl-functional, owl-manchester, rdf-jsonld, rdf-nq, rdf-nt, rdf-trix, rdf-turtle, rdf-xml, xcal, yaml]
          -f, --format
            a comma-separated list of writer factories, e.g.
            json,jsonld,nquads,notrivial,ntriples,trix,turtle,uri
            Default: [ntriples]
          -l, --log
            Produce log within a file.
          -n, --nesting
            Disable production of nesting triples.
            Default: false
          -t, --notrivial
            Filter trivial statements (e.g. CSS related ones). [DEPRECATED: As
            of version 2.3, use --format instead.]
            Default: false
          -o, --output
            Specify Output file (defaults to standard output)
            Default: java.io.PrintStream@2b2948e2
          -p, --pedantic
            Validate and fixes HTML content detecting commons issues.
            Default: false
          -s, --stats
            Print out extraction statistics.
            Default: false
``` 
