### PR TITLE
[ANY23-371] Any23 cannot start in CMD in Windows 10

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -304,6 +304,12 @@
     </dependency>
     <!-- END: additional dependencies used by RDF4J or Tika -->
 
+    <dependency>
+      <groupId>org.codehaus.mojo.appassembler</groupId>
+      <artifactId>appassembler-booter</artifactId>
+      <version>1.10</version>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -332,7 +338,8 @@
           <execution>
             <phase>package</phase>
             <goals>
-              <goal>assemble</goal>
+              <goal>generate-daemons</goal>
+              <goal>create-repository</goal>
             </goals>
           </execution>
         </executions>

--- a/cli/src/main/assembly/bin.xml
+++ b/cli/src/main/assembly/bin.xml
@@ -61,9 +61,16 @@
      | shell scripts
     -->
     <fileSet>
-      <directory>${project.build.directory}/appassembler/bin/</directory>
-      <outputDirectory>/bin</outputDirectory>
+      <directory>${project.build.directory}/generated-resources/appassembler/booter-unix/bin/</directory>
+      <outputDirectory>bin</outputDirectory>
       <fileMode>0755</fileMode>
+      <lineEnding>unix</lineEnding>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/generated-resources/appassembler/booter-windows/bin/</directory>
+      <outputDirectory>bin</outputDirectory>
+      <fileMode>0755</fileMode>
+      <lineEnding>dos</lineEnding>
     </fileSet>
 
     <!--
@@ -71,7 +78,7 @@
     -->
     <fileSet>
       <directory>${project.build.directory}/appassembler/lib/</directory>
-      <outputDirectory>/lib</outputDirectory>
+      <outputDirectory>lib</outputDirectory>
       <excludes>
         <exclude>*.xml</exclude>
       </excludes>
@@ -81,8 +88,15 @@
      | Configuration and Resources
     -->
     <fileSet>
+      <directory>${project.build.directory}/generated-resources/appassembler/booter-unix/etc/</directory>
+      <outputDirectory>etc</outputDirectory>
+      <includes>
+        <include>*.xml</include>
+      </includes>
+    </fileSet>
+    <fileSet>
       <directory>${project.build.directory}/appassembler/conf/</directory>
-      <outputDirectory>/conf</outputDirectory>
+      <outputDirectory>conf</outputDirectory>
     </fileSet>
   </fileSets>
 

--- a/pom.xml
+++ b/pom.xml
@@ -686,6 +686,16 @@
             <repositoryLayout>flat</repositoryLayout>
             <repositoryName>lib</repositoryName>
             <extraJvmArguments>-Xms500m -Xmx500m -XX:PermSize=128m -XX:-UseGCOverheadLimit</extraJvmArguments>
+            <daemons>
+              <daemon>
+                <id>any23</id>
+                <mainClass>org.apache.any23.cli.ToolRunner</mainClass>
+                <platforms>
+                  <platform>booter-unix</platform>
+                  <platform>booter-windows</platform>
+                </platforms>
+              </daemon>
+            </daemons>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
The long classpath is a known issue in the maven plug-in appassembler-maven-plugin. The description of the issue is here:
https://www.mojohaus.org/appassembler/appassembler-maven-plugin/faq.html#

This pull request solved this issue by implementing the "Booter" mechanism, which is described here:
https://www.mojohaus.org/appassembler/appassembler-maven-plugin/usage-booter.html

The generated any23.bat does not contain the long "set CLASSPATH=..." any more. The generated script runs on CMD even if the base path is very long.

![any23 bat](https://user-images.githubusercontent.com/386639/115126154-61a13900-9fcd-11eb-94a8-f0c21e36219a.png)
