### PR TITLE
ANY23-496 Bump tika.version from 1.27 to 2.1.0

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -127,7 +127,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
+      <artifactId>tika-parsers-standard-package</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -105,7 +105,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
+      <artifactId>tika-parsers-standard-package</artifactId>
     </dependency>
     <dependency> <!-- used by Tika -->
         <groupId>org.apache.commons</groupId>

--- a/encoding/pom.xml
+++ b/encoding/pom.xml
@@ -56,7 +56,7 @@
     <!-- BEGIN: Tika -->
     <dependency>
       <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
+      <artifactId>tika-parsers-standard-package</artifactId>
     </dependency>
     <!-- ensure dependencies of tika-parsers match versions
       specified in dependencyManagement section of parent pom -->

--- a/mime/pom.xml
+++ b/mime/pom.xml
@@ -87,7 +87,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
+      <artifactId>tika-parsers-standard-package</artifactId>
     </dependency>
     <!-- ensure dependencies of tika-parsers match versions
       specified in dependencyManagement section of parent pom -->

--- a/mime/src/main/java/org/apache/any23/mime/TikaMIMETypeDetector.java
+++ b/mime/src/main/java/org/apache/any23/mime/TikaMIMETypeDetector.java
@@ -23,6 +23,7 @@ import org.apache.any23.mime.purifier.WhiteSpacesPurifier;
 import org.apache.tika.Tika;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MimeType;
 import org.apache.tika.mime.MimeTypeException;
 import org.apache.tika.mime.MimeTypes;
@@ -275,7 +276,7 @@ public class TikaMIMETypeDetector implements MIMETypeDetector {
         if (mimeTypeFromMetadata != null)
             meta.set(Metadata.CONTENT_TYPE, mimeTypeFromMetadata.getFullType());
         if (fileName != null)
-            meta.set(Metadata.RESOURCE_NAME_KEY, fileName);
+            meta.set(TikaCoreProperties.RESOURCE_NAME_KEY, fileName);
 
         String type;
         try {
@@ -365,7 +366,7 @@ public class TikaMIMETypeDetector implements MIMETypeDetector {
         }
 
         // Determines the MIMEType based on resource name hint if available.
-        final String resourceName = metadata.get(Metadata.RESOURCE_NAME_KEY);
+        final String resourceName = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY);
         if (resourceName != null) {
             String type = tika.detect(resourceName);
             if (type != null && !type.equals(MimeTypes.OCTET_STREAM)) {

--- a/mime/src/test/java/org/apache/any23/mime/purifier/WhiteSpacesPurifierTest.java
+++ b/mime/src/test/java/org/apache/any23/mime/purifier/WhiteSpacesPurifierTest.java
@@ -17,13 +17,16 @@
 
 package org.apache.any23.mime.purifier;
 
-import org.apache.tika.io.IOUtils;
+import java.io.IOException;
+import java.io.BufferedInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.*;
 
 /**
  * Reference test case for {@link WhiteSpacesPurifier}.
@@ -50,7 +53,7 @@ public class WhiteSpacesPurifierTest {
                 this.getClass().getResourceAsStream("/application/xhtml/blank-file-header.xhtml"));
         this.purifier.purify(inputStream);
         Assert.assertNotNull(inputStream);
-        Assert.assertTrue(validatePurification(IOUtils.toString(inputStream)));
+        Assert.assertTrue(validatePurification(IOUtils.toString(inputStream, StandardCharsets.UTF_8)));
 
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -270,11 +270,11 @@
     <rdf4j.version>3.1.2</rdf4j.version>
     <semargl.version>0.7</semargl.version>
     <slf4j.logger.version>1.7.32</slf4j.logger.version>
-    <tika.version>1.27</tika.version>
+    <tika.version>2.1.0</tika.version>
     <openie_2.11.version>4.2.6</openie_2.11.version>
     <openregex.version>1.1.1</openregex.version>
     <jackson.version>2.12.5</jackson.version>
-    <commons-io.version>2.7</commons-io.version>
+    <commons-io.version>2.11.0</commons-io.version>
 
     <!-- Overridden in profiles to add JDK specific arguments to surefire -->
     <surefire-extra-args />
@@ -311,7 +311,7 @@
     <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
     <maven-invoker-plugin.version>3.2.1</maven-invoker-plugin.version>
     <spotbugs-maven-plugin.version>4.1.3</spotbugs-maven-plugin.version>
-    <forbiddenapis.version>3.1</forbiddenapis.version>
+    <forbiddenapis.version>3.2</forbiddenapis.version>
     <formatter-maven-plugin.version>2.14.0</formatter-maven-plugin.version>
 
     <!--
@@ -385,7 +385,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.tika</groupId>
-        <artifactId>tika-parsers</artifactId>
+        <artifactId>tika-parsers-standard-package</artifactId>
         <version>${tika.version}</version>
       </dependency>
       <dependency>
@@ -753,13 +753,13 @@
           <ignoreSignaturesOfMissingClasses>false</ignoreSignaturesOfMissingClasses>
           <bundledSignatures>
             <!-- https://github.com/policeman-tools/forbidden-apis/wiki/BundledSignatures -->
-            <bundledSignature>jdk-unsafe</bundledSignature>
-            <bundledSignature>jdk-deprecated</bundledSignature>
+            <bundledSignature>jdk-unsafe-${javac.src.version}</bundledSignature>
+            <bundledSignature>jdk-deprecated-${javac.src.version}</bundledSignature>
             <bundledSignature>jdk-non-portable</bundledSignature>
             <bundledSignature>jdk-reflection</bundledSignature>
-            <bundledSignature>jdk-internal</bundledSignature>
+            <bundledSignature>jdk-internal-${javac.src.version}</bundledSignature>
             <bundledSignature>jdk-system-out</bundledSignature>
-            <!--bundledSignature>commons-io-unsafe-2.8.0</bundledSignature-->
+            <bundledSignature>commons-io-unsafe-${commons-io.version}</bundledSignature>
           </bundledSignatures>
         </configuration>
         <executions>


### PR DESCRIPTION
This PR supersedes https://github.com/apache/any23/pull/183 and addresses https://issues.apache.org/jira/browse/ANY23-496