### PR TITLE
ANY23-504 Optionally disable remote HTTP connections when resolving XML entities

### DIFF
--- a/core/src/test/java/org/apache/any23/extractor/rdf/JSONLDExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/rdf/JSONLDExtractorTest.java
@@ -72,7 +72,6 @@ public class JSONLDExtractorTest {
         for (int i = 0; i <= Character.MAX_CODE_POINT; i++) {
             if (Character.isWhitespace(i) || Character.isSpaceChar(i)) {
                 byte[] bytes = new String(Character.toChars(i)).getBytes(StandardCharsets.UTF_8);
-                @SuppressWarnings("resource")
                 InputStream stream = new JsonCleaningInputStream(new ByteArrayInputStream(bytes));
                 if (i == '\r' || i == '\n') {
                     Assert.assertEquals(stream.read(), i);

--- a/core/src/test/java/org/apache/any23/extractor/rdf/TriXExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/rdf/TriXExtractorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.any23.extractor.rdf;
+
+import java.lang.invoke.MethodHandles;
+
+import org.apache.any23.extractor.ExtractorFactory;
+import org.apache.any23.extractor.html.AbstractExtractorTestCase;
+//import org.apache.any23.rdf.RDFUtils;
+//import org.eclipse.rdf4j.model.vocabulary.OWL;
+//import org.eclipse.rdf4j.model.vocabulary.RDF;
+//import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test case for {@link TriXExtractor}.
+ *
+ */
+public class TriXExtractorTest extends AbstractExtractorTestCase {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    @Override
+    public ExtractorFactory<?> getExtractorFactory() {
+        return new TriXExtractorFactory();
+    }
+
+    @Test
+    public void testExampleActivateTriXExtractorOnHTMLDocument() {
+        assertExtract("/org/apache/any23/extractor/rdf/BBC_News_Scotland.html");
+        logger.debug(dumpModelToNQuads());
+        assertStatementsSize(null, null, null, 2);
+        // assertContains(RDFUtils.iri("http://example.org/example-manchestersyntax"), RDF.TYPE, OWL.ONTOLOGY);
+        // assertContains(RDFUtils.iri("http://example.org/example-manchestersyntax#TestIndividual"), RDFS.COMMENT,
+        // "Test individual is a unique individual");
+    }
+
+}

--- a/test-resources/src/test/resources/org/apache/any23/extractor/rdf/BBC_News_Scotland.html
+++ b/test-resources/src/test/resources/org/apache/any23/extractor/rdf/BBC_News_Scotland.html
@@ -1,0 +1,3780 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html class=" blq-js" xmlns="http://www.w3.org/1999/xhtml" xmlns:og="http://opengraphprotocol.org/schema/" xmlns:rnews="http://iptc.org/std/rNews/2011-10-07#" xml:lang="en-GB"><!-- THIS FILE CONFIGURES SHARED HIGHWEB STATIC ASSETS --><!-- mapping_news.inc --><!-- THIS FILE CONFIGURES NEWS STATIC ASSETS  --><!-- THIS FILE CONFIGURES VOTE 2012 STATIC ASSETS  --><!-- hi/shared/head_initial.inc --><!-- IGOR News --><head profile="http://dublincore.org/documents/dcq-html/" resource="http://www.bbc.co.uk/news/scotland/" typeof="rnews:NewsItem">
+        <meta http-equiv="X-UA-Compatible" content="IE=8">
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <title>BBC News - Scotland</title>
+        <meta name="Description" content="Get the latest Scottish news from BBC Scotland: breaking news, analysis, features and debate plus audio and video coverage on topical issues from around Scotland">
+        <meta property="rnews:description" content="Get the latest Scottish news from BBC Scotland: breaking news, analysis, features and debate plus audio and video coverage on topical issues from around Scotland">
+                <meta name="OriginalPublicationDate" content="2014/03/31 13:53:03">
+        <meta property="rnews:datePublished" content="2014/03/31 13:53:03">
+        <meta name="UKFS_URL" content="/news/scotland/">
+                <meta name="Headline" content="INDEX ">
+        <meta property="rnews:headline" content="INDEX ">
+        <meta name="IFS_URL" content="/news/scotland/">
+        <meta name="Section" content="Scotland">
+        <meta name="contentFlavor" content="INDEX">
+		                        <meta name="CPS_ID" content="10059375">
+        <meta name="CPS_SITE_NAME" content="BBC News">
+        <meta name="CPS_SECTION_PATH" content="Scotland">
+        <meta name="CPS_ASSET_TYPE" content="IDX">
+        <meta name="CPS_PLATFORM" content="HighWeb">
+        <meta name="CPS_AUDIENCE" content="Domestic">
+        <meta property="rnews:creator" content="http://www.bbc.co.uk#org">
+
+            		<meta property="og:title" content="INDEX ">
+    		<meta property="og:type" content="article">
+    		<meta property="og:url" content="http://www.bbc.co.uk/news/scotland/">
+    		<meta property="og:site_name" content="BBC News">
+            			<meta property="og:image" content="http://newsimg.bbc.co.uk/media/images/67373000/jpg/_67373987_09f1654a-e583-4b5f-bfc4-f05850c6d3ce.jpg">
+											
+				<meta name="bbcsearch_noindex" content="atom">
+		
+        
+            <link rel="canonical" href="http://www.bbc.co.uk/news/scotland/">
+<link rel="alternate" hreflang="en" href="http://www.bbc.com/news/scotland/">
+<link rel="alternate" hreflang="en-gb" href="http://www.bbc.co.uk/news/scotland/">
+        
+
+        							<link href="http://feeds.bbci.co.uk/news/scotland/rss.xml" rel="alternate" type="application/rss+xml" title="BBC News - Scotland">
+					
+        
+
+        <!-- hi/news/head_first.inc -->
+
+<!-- Chartbeat Web Analytics code - start -->
+<script type="text/javascript">var _sf_startpt=(new Date()).getTime()</script>
+<!-- Chartbeat Web Analytics code - end -->
+
+<meta name="application-name" content="BBC News">
+<meta name="msapplication-TileImage" content="/img/1_0_3/cream/hi/news/bbc-news-pin.png">
+<meta name="msapplication-TileColor" content="#CC0101">
+
+
+<meta name="twitter:card" value="summary">
+
+        <!-- Project IGOR - Barlesque redirection logic - START -->
+
+
+    <script>
+        /*<![CDATA[*/
+        window.bbcredirection = {
+            
+                device: true,
+                geo: true
+            
+        }
+        /*]]>*/
+    </script>
+
+<!-- Project IGOR - Barlesque redirection logic - END -->
+
+
+<!-- PULSE_ENABLED:yes -->
+
+<!-- vars inc blq_cachebust_journalism 1.21.17 -->
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+	
+	
+		
+		
+	
+
+
+
+
+
+
+
+
+	
+		
+			
+				
+								
+							
+							
+				
+					
+					
+					
+					
+							
+									
+						
+				
+					
+					
+					
+					
+					
+					
+					
+					
+									
+											
+				
+				
+				
+								
+								
+			
+			
+						
+			
+		
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+		
+	
+		
+
+
+
+
+
+
+	
+		
+
+    
+   <meta http-equiv="X-UA-Compatible" content="IE=8">  
+  <link rel="schema.dcterms" href="http://purl.org/dc/terms/">  <link rel="index" href="http://www.bbc.co.uk/a-z/" title="A to Z"> <link rel="copyright" href="http://www.bbc.co.uk/terms/" title="Terms of Use"> <link rel="icon" href="http://www.bbc.co.uk/favicon.ico" type="image/x-icon">  <meta name="viewport" content="width = 996"> 
+
+<script type="text/javascript">/*<![CDATA[*/
+window.orb = window.orb || {};
+(function() {
+    'use strict';
+    window.fig = window.fig || {};
+    window.fig.manager = {
+                include: function(w) {
+            w = w || window;
+            var d = w.document,
+                c = d.cookie,
+                f = c.match(/ckns_orb_fig=([^;]+)/);
+
+            if ( !f && c.indexOf('ckns_orb_nofig=1') > -1 ) {
+                this.setFig(w, {no:1});
+            }
+            else {
+                if (f) {
+                    eval('f = ' + decodeURIComponent(RegExp.$1) + ';')
+                    this.setFig(w, f);                  
+                }
+                d.write('<script src="https://ssl.live.bbc.co.uk/frameworks/fig/1/fig.js"><'+'/script>');
+            }         
+  
+        },
+                confirm: function(w) {
+            w = w || window;
+            if (w.orb && w.orb.fig && w.orb.fig('no')) {
+               this.setFigCookie(w);
+            }
+            
+            if (w.orb === undefined || w.orb.fig === undefined) {
+                this.setFig(w, {no:1});
+                this.setFigCookie(w);
+            }
+        },
+                setFigCookie: function(w) {
+            w.document.cookie = 'ckns_orb_nofig=1; expires=' + new Date(new Date().getTime() + 1000 * 60 * 10).toGMTString() + ';';
+        },
+                setFig: function(w, f){
+            (function(){var o=f;w.orb=w.orb||{};w.orb.fig=function(k){return (arguments.length)? o[k]:o};})();
+        }
+    }
+})();
+fig.manager.include();
+/*]]>*/</script><script src="BBC_News_Scotland_files/fig.js"></script>
+<script type="text/javascript"> fig.manager.confirm(); </script>
+
+ <link rel="stylesheet" type="text/css" href="BBC_News_Scotland_files/main.css">  <script type="text/javascript">/*<![CDATA[*/ (function(undefined){if(!window.bbc){window.bbc={}}var ROLLING_PERIOD_DAYS=30;window.bbc.Mandolin=function(id,segments,opts){var now=new Date().getTime(),storedItem,DEFAULT_START=now,DEFAULT_RATE=1,COOKIE_NAME="ckpf_mandolin";opts=opts||{};this._id=id;this._segmentSet=segments;this._store=new window.window.bbc.Mandolin.Storage(COOKIE_NAME);this._opts=opts;this._rate=(opts.rate!==undefined)?+opts.rate:DEFAULT_RATE;this._startTs=(opts.start!==undefined)?new Date(opts.start).getTime():new Date(DEFAULT_START).getTime();this._endTs=(opts.end!==undefined)?new Date(opts.end).getTime():daysFromNow(ROLLING_PERIOD_DAYS);this._signupEndTs=(opts.signupEnd!==undefined)?new Date(opts.signupEnd).getTime():this._endTs;this._segment=null;if(typeof id!=="string"){throw new Error("Invalid Argument: id must be defined and be a string")}if(Object.prototype.toString.call(segments)!=="[object Array]"){throw new Error("Invalid Argument: Segments are required.")}if(opts.rate!==undefined&&(opts.rate<0||opts.rate>1)){throw new Error("Invalid Argument: Rate must be between 0 and 1.")}if(this._startTs>this._endTs){throw new Error("Invalid Argument: end date must occur after start date.")}if(!(this._startTs<this._signupEndTs&&this._signupEndTs<=this._endTs)){throw new Error("Invalid Argument: SignupEnd must be between start and end date")}removeExpired.call(this,now);if((storedItem=this._store.getItem(this._id))){this._segment=storedItem.segment}else{if(this._startTs<=now&&now<this._signupEndTs&&now<=this._endTs&&this._store.isEnabled()===true){this._segment=pick(segments,this._rate);if(opts.end===undefined){this._store.setItem(this._id,{segment:this._segment})}else{this._store.setItem(this._id,{segment:this._segment,end:this._endTs})}log.call(this,"mandolin_segment")}}log.call(this,"mandolin_view")};window.bbc.Mandolin.prototype.getSegment=function(){return this._segment};function log(actionType,params){var that=this;require(["istats-1"],function(istats){istats.log(actionType,that._id+":"+that._segment,params?params:{})})}function removeExpired(expires){var items=this._store.getItems(),expiresInt=+expires;for(var key in items){if(items[key].end!==undefined&&+items[key].end<expiresInt){this._store.removeItem(key)}}}function getLastExpirationDate(data){var winner=0,rollingExpire=daysFromNow(ROLLING_PERIOD_DAYS);for(var key in data){if(data[key].end===undefined&&rollingExpire>winner){winner=rollingExpire}else{if(+data[key].end>winner){winner=+data[key].end}}}return(winner)?new Date(winner):new Date(rollingExpire)}window.bbc.Mandolin.prototype.log=function(params){log.call(this,"mandolin_log",params)};window.bbc.Mandolin.prototype.convert=function(params){log.call(this,"mandolin_convert",params);this.convert=function(){}};function daysFromNow(n){var endDate;endDate=new Date().getTime()+(n*60*60*24)*1000;return endDate}function pick(segments,rate){var picked,min=0,max=segments.length-1;if(typeof rate==="number"&&Math.random()>rate){return null}do{picked=Math.floor(Math.random()*(max-min+1))+min}while(picked>max);return segments[picked]}window.bbc.Mandolin.Storage=function(name){this._cookieName=name;this._isEnabled=(bbccookies.isAllowed(this._cookieName)===true&&bbccookies.cookiesEnabled()===true)};window.bbc.Mandolin.Storage.prototype.setItem=function(key,value){var storeData=this.getItems();storeData[key]=value;this.save(storeData);return value};window.bbc.Mandolin.Storage.prototype.isEnabled=function(){return this._isEnabled};window.bbc.Mandolin.Storage.prototype.getItem=function(key){var storeData=this.getItems();return storeData[key]};window.bbc.Mandolin.Storage.prototype.removeItem=function(key){var storeData=this.getItems();delete storeData[key];this.save(storeData)};window.bbc.Mandolin.Storage.prototype.getItems=function(){return deserialise(this.readCookie(this._cookieName)||"")};window.bbc.Mandolin.Storage.prototype.save=function(data){window.bbccookies.set(this._cookieName+"="+encodeURIComponent(serialise(data))+"; expires="+getLastExpirationDate(data).toUTCString()+";")};window.bbc.Mandolin.Storage.prototype.readCookie=function(name){var nameEQ=name+"=",ca=window.bbccookies.get().split(";"),i,c;for(i=0;i<ca.length;i++){c=ca[i];while(c.charAt(0)===" "){c=c.substring(1,c.length)}if(c.indexOf(nameEQ)===0){return decodeURIComponent(c.substring(nameEQ.length,c.length))}}return null};function serialise(o){var str="";for(var p in o){if(o.hasOwnProperty(p)){str+='"'+p+'"'+":"+(typeof o[p]==="object"?(o[p]===null?"null":"{"+serialise(o[p])+"}"):'"'+o[p].toString().replace(/"/g,'\\"')+'"')+","}}return str.replace(/,\}/g,"}").replace(/,$/g,"")}function deserialise(str){var o;eval("o = {"+str+"}");return o}})(); /*]]>*/</script>  <script type="text/javascript">/*<![CDATA[*/ if (typeof bbccookies_flag === 'undefined') { bbccookies_flag = 'ON'; } showCTA_flag = true; cta_enabled = (showCTA_flag && (bbccookies_flag === 'ON') ); (function(){var e="ckns_policy",m="Thu, 01 Jan 1970 00:00:00 GMT",k={ads:true,personalisation:true,performance:true,necessary:true};function f(p){if(f.cache[p]){return f.cache[p]}var o=p.split("/"),q=[""];do{q.unshift((o.join("/")||"/"));o.pop()}while(q[0]!=="/");f.cache[p]=q;return q}f.cache={};function a(p){if(a.cache[p]){return a.cache[p]}var q=p.split("."),o=[];while(q.length&&"|co.uk|com|".indexOf("|"+q.join(".")+"|")===-1){if(q.length){o.push(q.join("."))}q.shift()}f.cache[p]=o;return o}a.cache={};function i(o,t,p){var z=[""].concat(a(window.location.hostname)),w=f(window.location.pathname),y="",r,x;for(var s=0,v=z.length;s<v;s++){r=z[s];for(var q=0,u=w.length;q<u;q++){x=w[q];y=o+"="+t+";"+(r?"domain="+r+";":"")+(x?"path="+x+";":"")+(p?"expires="+p+";":"");bbccookies.set(y,true)}}}window.bbccookies={_setEverywhere:i,cookiesEnabled:function(){var o="ckns_testcookie"+Math.floor(Math.random()*100000);this.set(o+"=1");if(this.get().indexOf(o)>-1){g(o);return true}return false},set:function(o){return document.cookie=o},get:function(){return document.cookie},_setPolicy:function(o){return h.apply(this,arguments)},readPolicy:function(o){return b.apply(this,arguments)},_deletePolicy:function(){i(e,"",m)},isAllowed:function(){return true},_isConfirmed:function(){return c()!==null},_acceptsAll:function(){var o=b();return o&&!(j(o).indexOf("0")>-1)},_getCookieName:function(){return d.apply(this,arguments)},_showPrompt:function(){var o=(!this._isConfirmed()&&window.cta_enabled&&this.cookiesEnabled()&&!window.bbccookies_disable);return(window.orb&&window.orb.fig)?o&&(window.orb.fig("no")||window.orb.fig("ck")):o}};bbccookies._getPolicy=bbccookies.readPolicy;function d(p){var o=(""+p).match(/^([^=]+)(?==)/);return(o&&o.length?o[0]:"")}function j(o){return""+(o.ads?1:0)+(o.personalisation?1:0)+(o.performance?1:0)}function h(r){if(typeof r==="undefined"){r=k}if(typeof arguments[0]==="string"){var o=arguments[0],q=arguments[1];if(o==="necessary"){q=true}r=b();r[o]=q}else{if(typeof arguments[0]==="object"){r.necessary=true}}var p=new Date();p.setYear(p.getFullYear()+1);p=p.toUTCString();bbccookies.set(e+"="+j(r)+";domain=bbc.co.uk;path=/;expires="+p+";");bbccookies.set(e+"="+j(r)+";domain=bbc.com;path=/;expires="+p+";");return r}function l(o){if(o===null){return null}var p=o.split("");return{ads:!!+p[0],personalisation:!!+p[1],performance:!!+p[2],necessary:true}}function c(){var o=new RegExp("(?:^|; ?)"+e+"=(\\d\\d\\d)($|;)"),p=document.cookie.match(o);if(!p){return null}return p[1]}function b(o){var p=l(c());if(!p){p=k}if(o){return p[o]}else{return p}}function g(o){return document.cookie=o+"=;expires="+m+";"}function n(){var o='<script type="text/javascript" src="http://static.bbci.co.uk/frameworks/bbccookies/0.6.3/script/bbccookies.js"><\/script>';if(window.bbccookies_flag==="ON"&&!bbccookies._acceptsAll()&&!window.bbccookies_disable){document.write(o)}}n()})(); /*]]>*/</script>      <script type="text/javascript"> if (! window.gloader) { window.gloader = [ "glow", {map: "http://node1.bbcimg.co.uk/glow/glow/map.1.7.7.js"}]; } </script>  <script type="text/javascript" src="BBC_News_Scotland_files/gloader.js"></script><script type="text/javascript" src="BBC_News_Scotland_files/map.js"></script>
+   <script type="text/javascript" src="BBC_News_Scotland_files/require.js"></script> <script type="text/javascript">  bbcRequireMap = {"jquery-1":"http://static.bbci.co.uk/frameworks/jquery/0.3.0/sharedmodules/jquery-1.7.2", "jquery-1.4":"http://static.bbci.co.uk/frameworks/jquery/0.3.0/sharedmodules/jquery-1.4", "jquery-1.9":"http://static.bbci.co.uk/frameworks/jquery/0.3.0/sharedmodules/jquery-1.9.1", "swfobject-2":"http://static.bbci.co.uk/frameworks/swfobject/0.1.10/sharedmodules/swfobject-2", "demi-1":"http://static.bbci.co.uk/frameworks/demi/0.10.0/sharedmodules/demi-1", "gelui-1":"http://static.bbci.co.uk/frameworks/gelui/0.9.13/sharedmodules/gelui-1", "cssp!gelui-1/overlay":"http://static.bbci.co.uk/frameworks/gelui/0.9.13/sharedmodules/gelui-1/overlay.css", "istats-1":"http://static.bbci.co.uk/frameworks/istats/0.17.2/modules/istats-1", "relay-1":"http://static.bbci.co.uk/frameworks/relay/0.2.4/sharedmodules/relay-1", "clock-1":"http://static.bbci.co.uk/frameworks/clock/0.1.9/sharedmodules/clock-1", "canvas-clock-1":"http://static.bbci.co.uk/frameworks/clock/0.1.9/sharedmodules/canvas-clock-1", "cssp!clock-1":"http://static.bbci.co.uk/frameworks/clock/0.1.9/sharedmodules/clock-1.css", "jssignals-1":"http://static.bbci.co.uk/frameworks/jssignals/0.3.6/modules/jssignals-1", "jcarousel-1":"http://static.bbci.co.uk/frameworks/jcarousel/0.1.10/modules/jcarousel-1"}; require({ baseUrl: 'http://static.bbci.co.uk/', paths: bbcRequireMap, waitSeconds: 30 }); </script>      <script type="text/javascript" src="BBC_News_Scotland_files/barlesque.js"></script>
+  
+<!--[if IE 6]>
+        <script type="text/javascript">
+        try {
+            document.execCommand("BackgroundImageCache",false,true);
+        } catch(e) {}
+    </script>
+        <style type="text/css">
+        /* Use filters for IE6 */
+        #blq-blocks a {
+            background-image: none;
+            filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src='http://static.bbci.co.uk/frameworks/barlesque/2.60.1/desktop/3.5//img/blq-blocks_white_alpha.png', sizingMethod='image');
+        }
+        .blq-masthead-focus #blq-blocks a,
+        .blq-mast-text-dark #blq-blocks a {
+            background-image: none;
+            filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src='http://static.bbci.co.uk/frameworks/barlesque/2.60.1/desktop/3.5//img/blq-blocks_grey_alpha.png', sizingMethod='image');
+        }
+        #blq-nav-search button span {
+            background-image: none;
+            filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src='http://static.bbci.co.uk/frameworks/barlesque/2.60.1/desktop/3.5//img/blq-search_grey_alpha.png', sizingMethod='image');
+        }
+        #blq-nav-search button img {
+            position: absolute;
+            left: -999em;    
+        }
+    </style>
+<![endif]-->
+
+<!--[if (IE 7])|(IE 8)>
+    <style type="text/css">
+        .blq-clearfix {
+            display: inline-block;
+        }
+    </style>
+<![endif]-->
+
+<script type="text/javascript">
+     blq.setEnvironment('live');  if (blq.setLabel) blq.setLabel('searchSuggestion', "Search");  if (! /bbc\.co\.uk$/i.test(window.location.hostname) ) { document.documentElement.className += ' blq-not-bbc-co-uk'; } </script>
+
+  <script type="text/javascript"> /*<![CDATA[*/ function oqsSurveyManager(w, flag) {  var defaultThreshold = 0.7, usePulseThreshold = (flag === 'OFF')? 1 : defaultThreshold, activeThreshold; w.oqs = w.oqs || {}; if ( w.document.cookie.match(/(?:^|; *)ckns_oqs_usePulseThreshold=([\d.]+)/) ) { activeThreshold = RegExp.$1; } else if (typeof w.oqs_usePulseThreshold !== 'undefined') { activeThreshold = w.oqs_usePulseThreshold; } else { activeThreshold = usePulseThreshold; } w.oqs.usePulse = (w.Math.random() < activeThreshold); if (!w.oqs.usePulse) {  w.document.write('<script type="text/javascript" src="http://static.bbci.co.uk/frameworks/barlesque/2.60.1/desktop/3.5/script/vendor/edr.js"><'+'/script>'); } } oqsSurveyManager(window, 'ON'); /*]]>*/ </script> 
+ <script type="text/javascript"> window.pulse = { init: function(){/*stub*/} }; if (!window.oqs || oqs.usePulse) { document.write('<script type="text/javascript" src="http://static.bbci.co.uk/frameworks/pulsesurvey/0.10.1/script/pulse.js"><'+'/script>'); document.write('<script type="text/javascript" src="http://www.bbc.co.uk/survey/pulse/conf.js"><'+'/script>'); } </script><script type="text/javascript" src="BBC_News_Scotland_files/pulse.js"></script><script src="BBC_News_Scotland_files/jquery-1_002.js" data-requiremodule="jquery-1.9" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script type="text/javascript" src="BBC_News_Scotland_files/conf.js"></script> <script type="text/javascript"> pulse.translations = { intro: 'We are always looking to improve the site and your opinions count.', question: 'Do you have a few minutes to tell us what you think about this site?', accept: 'Yes', reject: 'No' };  </script> <link rel="stylesheet" href="BBC_News_Scotland_files/pulse.css" type="text/css"> <!--[if gte IE 6]> <style type="text/css"> .pulse-pop li{display:inline;width:40px} </style> <![endif]--> <!--[if IE 6]> <style type="text/css"> .pulse-pop li{display:inline;width:40px} .pulse-pop #pulse-q{background:url(http://static.bbci.co.uk/frameworks/pulsesurvey/0.10.1/img/pulse_bg.gif) no-repeat} .pulse-pop #pulse-a{background:url(http://static.bbci.co.uk/frameworks/pulsesurvey/0.10.1/img/pulse_bg.gif) bottom no-repeat;} </style> <![endif]--> <!--[if IE 7]> <style type="text/css">  .pulse-pop #pulse-a{zoom:1} </style> <![endif]-->  <script type="text/javascript"> /* <![CDATA[ */ define('id-statusbar-config', { 'translation_signedout': "Sign in", 'translation_signedin': "Your account", 'use_overlay' : false, 'signin_url' : "https://ssl.bbc.co.uk/id/signin?ptrt=http://www.bbc.co.uk/news/scotland/", 'locale' : "en-GB", 'policyname' : "", 'ptrt' : "http://www.bbc.co.uk/news/scotland/" }); /* ]]> */ </script>  <script type="text/javascript"> (function () { if (! window.require) { throw new Error('idcta: could not find require'); } var map = {}; map['idapp-1'] = 'http://static.bbci.co.uk/idapp/0.63.3/modules/idapp/idapp-1'; map['idcta/idcta-1'] = 'http://static.bbci.co.uk/id/0.23.1/modules/idcta/idcta-1'; require({paths: map}); define('id-config', {"idapp":{"version":"0.63.3","hostname":"ssl.bbc.co.uk","insecurehostname":"www.bbc.co.uk","tld":"bbc.co.uk"},"idtranslations":{"version":"0.27.2"},"identity":{"baseUrl":"https:\/\/talkback.live.bbc.co.uk\/identity"},"pathway":{"name":null,"staticAssetUrl":"http:\/\/static.bbci.co.uk\/idapp\/0.63.3\/modules\/idapp\/idapp-1\/View.css"}}); })(); </script>                          
+	
+
+
+
+
+		<!-- shared/head -->
+<meta http-equiv="imagetoolbar" content="no">
+<!--[if !(lt IE 6)]>
+   	<link rel="stylesheet" type="text/css" href="http://news.bbcimg.co.uk/view/3_0_19/cream/hi/shared/type.css" />
+
+
+		<link rel="stylesheet" type="text/css" media="screen" href="http://news.bbcimg.co.uk/view/3_0_19/cream/hi/shared/global.css" />
+
+
+	<link rel="stylesheet" type="text/css" media="print" href="http://news.bbcimg.co.uk/view/3_0_19/cream/hi/shared/print.css" />
+
+	<link rel="stylesheet" type="text/css" media="screen and (max-device-width: 976px)" href="http://news.bbcimg.co.uk/view/3_0_19/cream/hi/shared/mobile.css" />
+	
+
+
+
+<link rel="stylesheet" type="text/css" href="http://news.bbcimg.co.uk/view/3_0_19/cream/hi/shared/components/components.css" />
+
+<![endif]-->
+<!--[if !IE]>-->
+   	<link rel="stylesheet" type="text/css" href="BBC_News_Scotland_files/type.css">
+
+
+		<link rel="stylesheet" type="text/css" media="screen" href="BBC_News_Scotland_files/global.css">
+
+
+	<link rel="stylesheet" type="text/css" media="print" href="BBC_News_Scotland_files/print.css">
+
+	<link rel="stylesheet" type="text/css" media="screen and (max-device-width: 976px)" href="BBC_News_Scotland_files/mobile.css">
+	
+
+
+
+<link rel="stylesheet" type="text/css" href="BBC_News_Scotland_files/components.css">
+
+<!--<![endif]-->
+<script type="text/javascript">
+/*<![CDATA[*/
+gloader.load(["glow","1","glow.dom"],{onLoad:function(glow){glow.dom.get("html").addClass("blq-js")}});
+gloader.load(["glow","1","glow.dom"],{onLoad:function(glow){glow.ready(function(){if (glow.env.gecko){var gv = glow.env.version.split(".");for (var i=gv.length;i<4;i++){gv[i]=0;}if((gv[0]==1 && gv[1]==9 && gv[2]==0)||(gv[0]==1 && gv[1]<9)||(gv[0]<1)){glow.dom.get("body").addClass("firefox-older-than-3-5");}}});}});
+
+window.disableFacebookSDK=true;
+if (window.location.pathname.indexOf('+')>=0){window.disableFacebookSDK=true;}
+
+/*]]>*/
+</script><script type="text/javascript" src="BBC_News_Scotland_files/core_002.js" class="gloaded sync"></script>
+
+<script type="text/javascript" src="BBC_News_Scotland_files/locator.js"></script><script type="text/javascript" src="BBC_News_Scotland_files/widgets.js" class="gloaded sync"></script><link class="gloaded async" type="text/css" rel="stylesheet" href="BBC_News_Scotland_files/widgets.css">
+
+
+<script type="text/javascript" src="BBC_News_Scotland_files/bbc_fmtj.js"></script>
+
+<script type="text/javascript">
+<!--
+	bbc.fmtj.page = {
+		serverTime: 1396274136000,
+		editionToServe: 'domestic',
+		queryString: null,
+		section: 'scotland',
+		sectionPath: '/Scotland',
+		siteName: 'BBC News',
+		siteToServe: 'news',
+		siteVersion: 'cream',
+		storyId: '10059375',
+		assetType: 'index',
+		uri: '/news/scotland/',
+		country: 'gb',
+		masthead: false,
+		adKeyword: null,
+		templateVersion: 'v1_0'
+	}
+-->
+</script>
+<script type="text/javascript" src="BBC_News_Scotland_files/bbc_fmtj_common.js"></script>
+
+
+<script type="text/javascript">$useMap({map:"http://news.bbcimg.co.uk/js/map/map_0_0_33.js"});</script><script type="text/javascript" src="BBC_News_Scotland_files/map_0_0_33.js"></script>
+
+<script type="text/javascript">$loadView("0.0",["bbc.fmtj.view"]);</script><script type="text/javascript" src="BBC_News_Scotland_files/view.js" class="gloaded sync"></script>
+
+<script type="text/javascript">$render("livestats-heatmap");</script>
+
+
+<script type="text/javascript" src="BBC_News_Scotland_files/bbc_fmtj_config.js"></script>
+
+
+
+
+<script type="text/javascript">
+    //<![CDATA[
+        require(['jquery-1'], function($){
+            
+            // set up EMP once it's loaded
+            var setUp = function(){
+                // use our own pop out page
+        	    embeddedMedia.setPopoutUrl('/player/emp/2_0_55/popout/pop.stm');
+
+        	    // store EMP's notifyParent function
+        	    var oldNotifyParent = embeddedMedia.console.notifyParent;
+        	    // use our own to add livestats to popout
+        	    embeddedMedia.console.notifyParent = function(childWin){
+        	        oldNotifyParent(childWin);
+        	        // create new live stats url
+                    var liveStatsUrl = bbc.fmtj.av.emp.liveStatsForPopout($('#livestats').attr('src'));
+                    var webBug = $('<img />', {
+                                     id:  'livestats',
+                                     src: liveStatsUrl
+                                 });
+                    // append it to popout
+                    $(childWin.document).find('body').append(webBug);
+                }
+            }
+                
+            // check if console is available to manipulate
+            if(window.embeddedMedia && window.embeddedMedia.console){
+                setUp();
+            }
+            // otherwise emp is still loading, so add event listener
+            else{
+                $(document).bind('empReady', function(){
+                    setUp();
+                });
+            }
+        });
+    //]]>
+</script>
+
+
+		
+	<!-- get BUMP from cdn -->
+    <script type="text/javascript" src="BBC_News_Scotland_files/bump.js"></script>
+
+<!-- load glow and required modules -->
+<script type="text/javascript">
+    //<![CDATA[
+        gloader.load(['glow', '1', 'glow.dom']);
+    //]]>
+</script>
+
+
+
+	<!-- pull in our emp code -->
+	<script type="text/javascript" src="BBC_News_Scotland_files/emp.js"></script>
+	<!-- pull in compatibility.js -->
+	<script type="text/javascript" src="BBC_News_Scotland_files/compatibility.js"></script>
+
+
+<script type="text/javascript">
+	//<![CDATA[
+	    
+	
+	    
+	        
+	    
+	
+	    
+	        
+	    
+	
+	    // set site specific config
+	    
+	        bbc.fmtj.av.emp.configs.push('news');
+	    
+	    
+	    // when page loaded, write all created emps
+	    glow.ready(function(){
+			if(typeof bbcdotcom !== 'undefined' && bbcdotcom.av && bbcdotcom.av.emp){
+				bbcdotcom.av.emp.configureAll();
+			}
+			embeddedMedia.each(function(emp){
+				emp.set('enable3G', true);
+				emp.setMediator('href', '{protocol}://{host}/mediaselector/5/select/version/2.0/mediaset/{mediaset}/vpid/{id}');						
+			});
+			embeddedMedia.writeAll();
+	        // mark the emps as loaded
+	        bbc.fmtj.av.emp.loaded = true;
+			
+			
+	    });
+	//]]>
+</script>
+<!-- Check for advertising testing -->
+
+<meta name="viewport" content="width = 996">
+
+
+
+        <!-- shared/head_index -->
+<!-- THESE STYLESHEETS VARY ACCORDING TO PAGE CONTENT -->
+
+<link rel="stylesheet" type="text/css" media="screen" href="BBC_News_Scotland_files/index.css">
+
+
+<!-- js index view -->
+<script type="text/javascript">$loadView("0.0",["bbc.fmtj.view.news.index"]);</script><script src="BBC_News_Scotland_files/jquery-1.js" data-requiremodule="jquery-1" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="BBC_News_Scotland_files/demi-1.js" data-requiremodule="demi-1" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script type="text/javascript" src="BBC_News_Scotland_files/news-index.js" class="gloaded sync"></script><script src="BBC_News_Scotland_files/useragent.jsonp" data-requiremodule="http://open.live.bbc.co.uk/wurfldemi/useragent.jsonp?callback=define&amp;ua=Mozilla%2F5.0%20(X11%3B%20Ubuntu%3B%20Linux%20i686%3B%20rv%3A28.0)%20Gecko%2F20100101%20Firefox%2F28.0" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script>
+
+
+
+        
+        <!-- #CREAM hi news domestic head.inc -->
+
+<script type="text/javascript">
+	if(undefined !== bbc && undefined !== bbc.fmtj){
+		bbc.fmtj.makeNewsSurveyConfig = function(surveyId,probabilityRate){	
+			if(surveyId !== undefined){
+				pulse.localSurvey = {
+					'active' : true,
+					'URLFormat' : 'http://ecustomeropinions.com/survey/survey.php?sid='+ surveyId,
+					'probability' : probabilityRate,
+					'translations' : {
+						'intro' : 'We are always looking to improve the site and your opinions count.',
+						'question' : 'Do you have a few minutes to tell us what you think about this site?'
+					}				
+				}
+							
+							
+			}
+		};
+	}
+	</script>
+
+	
+    
+
+
+
+                            <!-- is suitable for ads adding isadvertise ... -->
+			
+
+			 
+
+			
+	
+	
+<script type="text/javascript">/*<![CDATA[*/if(bbcdotcom===undefined){var bbcdotcom={init:function(a){},objects:function(a){return false},domLoaded:false,data:{ads:0,stats:0,statsProvider:null},adverts:{slot:function(b,a){},layout:{reset:function(){}}},config:{isActive:function(a){return false}},addLoadEvent:function(a){var b=window.onload;if(typeof window.onload!="function"){window.onload=a}else{window.onload=function(){if(b){b()}a()}}}}}bbcdotcom.objects=function(d,e,f){var b,c,a;b=d.split(".");if(e===undefined){e="valid"}if(f===undefined){f=window}for(c=0,a=b.length;c<a;c++){if(f[b[c]]===undefined){if(e==="create"){f[b[c]]={}}else{return false}}else{if(typeof f[b[c]]==="function"){if(f[b[c]]()!==undefined){return f[b[c]]()}}}f=f[b[c]]}return f};bbcdotcom.objects("bbcdotcom.config","create");bbcdotcom.config=(function(e,c){var b=e,a=c,d="",f="",g="";return{setAdsEnabled:function(h){b=(b!==0)?h:0},isAdsEnabled:function(){return b},setAnalyticsEnabled:function(h){a=(a!==0)?h:0},isAnalyticsEnabled:function(){return a},setJsPrefix:function(h){d=h},getJsPrefix:function(){return d},setSwfPrefix:function(h){f=h},getSwfPrefix:function(){return f},setCssPrefix:function(h){g=h},getCssPrefix:function(){return g}}}(1,1));bbcdotcom.objects("bbcdotcom.stats","create");if(BBC===undefined){var BBC={}}if(BBC.adverts===undefined){BBC.adverts={setZone:function(){},configure:function(){},write:function(){},show:function(){},isActive:function(){return false},setScriptRoot:function(){},setImgRoot:function(){},getAdvertTag:function(){},getSectionPath:function(){}}};/*]]>*/</script>
+<meta name="application-name" content="BBC">
+<meta name="msapplication-tooltip" content="Explore the BBC, for latest news, sport and weather, TV &amp; radio schedules and highlights, with nature, food, comedy, children's programmes and much more">
+
+	<meta name="msapplication-starturl" content="http://www.bbc.com/news/?ocid=global-news-pinned-ie9">
+
+<meta name="msapplication-window" content="width=1024;height=768">
+<meta name="msapplication-task" content="name=BBC Home;action-uri=http://www.bbc.com/?ocid=global-homepage-pinned-ie9;icon-uri=http://news.bbcimg.co.uk/shared/img/bbccom/favicon_16.ico">
+<meta name="msapplication-task" content="name=BBC News;action-uri=http://www.bbc.com/news/?ocid=global-news-pinned-ie9;icon-uri=http://news.bbcimg.co.uk/shared/img/bbccom/favicon_16.ico">
+<meta name="msapplication-task" content="name=BBC Sport;action-uri=http://www.bbc.com/sport/0/?ocid=global-sport-pinned-ie9;icon-uri=http://news.bbcimg.co.uk/shared/img/bbccom/favicon_16.ico">
+<meta name="msapplication-task" content="name=BBC Future;action-uri=http://www.bbc.com/future?ocid=global-future-pinned-ie9;icon-uri=http://news.bbcimg.co.uk/shared/img/bbccom/favicon_16.ico">
+<meta name="msapplication-task" content="name=BBC Travel;action-uri=http://www.bbc.com/travel?ocid=global-travel-pinned-ie9;icon-uri=http://news.bbcimg.co.uk/shared/img/bbccom/favicon_16.ico">
+<meta name="msapplication-task" content="name=BBC Weather;action-uri=http://www.bbc.co.uk/weather/?ocid=global-weather-pinned-ie9;icon-uri=http://news.bbcimg.co.uk/shared/img/bbccom/favicon_16.ico">
+<!-- BBCCOM client-side -->
+
+
+<style type="text/css">.bbccom_display_none{display:none;}</style>
+
+
+<script type="text/javascript">/*<![CDATA[*/
+    if (typeof orb !== 'undefined' && typeof orb.fig === 'function') {
+        bbcdotcom.data = {
+            a: orb.fig('ad')? 1 : 0,
+            b: (0 == orb.fig('uk')) ? 1 : 0,
+            c: orb.fig('ap')
+        };
+    } else {
+        document.write(unescape('%3Cscript type="text/javascript" src="http://tps.bbc.com/wwscripts/data"%3E%3C/script%3E'));
+    }
+/*]]>*/</script>
+<script type="text/javascript">/*<![CDATA[*/
+    if (typeof bbcdotcom.data == 'undefined' || typeof bbcdotcom.data.a == 'undefined' || typeof bbcdotcom.data.b == 'undefined' || typeof bbcdotcom.data.c == 'undefined') {
+        bbcdotcom.data = {a:0,b:0,c:0};
+    }
+    if (bbcdotcom.data.a == 1) {
+        document.write(unescape('%3Clink href="http://news.bbcimg.co.uk/css/screen/shared/0.3.236/3pt_ads.css" rel="stylesheet" type="text/css" /%3E'));
+        
+            document.write(unescape('%3Cscript type="text/javascript" src="http://www.bbc.co.uk/wwscripts/flag"%3E%3C/script%3E'));
+        
+    }
+/*]]>*/</script>
+<script type="text/javascript">/*<![CDATA[*/
+    if (typeof bbcdotcom.flag == 'undefined' || bbcdotcom.flag.a != 1) {
+        bbcdotcom.data.a = 0;
+    }
+    if (bbcdotcom.data.a == 1 || bbcdotcom.data.b == 1) {
+        document.write(unescape('%3Cscript type="text/javascript" src="http://news.bbcimg.co.uk/js/app/bbccom/0.3.236/bbccom.js"%3E%3C/script%3E'));
+    }
+/*]]>*/</script>
+<script type="text/javascript">/*<![CDATA[*/
+    if (bbcdotcom.data.a == 1 || bbcdotcom.data.b == 1) {
+        BBC.adverts.setData(bbcdotcom.data);
+        bbcdotcom.config.setAdsEnabled(bbcdotcom.data.a);
+        bbcdotcom.config.setAnalyticsEnabled(bbcdotcom.data.b);
+        if(typeof bbcdotcom !== 'undefined' && typeof bbcdotcom.survey !== 'undefined' && typeof bbcdotcom.survey.init === 'function') {
+            bbcdotcom.survey.init();
+        }
+    }
+    bbcdotcom.objects('page', 'create', bbcdotcom);
+    bbcdotcom.page.edition = '(none)';
+    bbcdotcom.page.url = '/news/scotland/';
+    bbcdotcom.page.zoneFile = '3pt_zone_file';
+    bbcdotcom.page.http_host = 'www.bbc.co.uk';
+    
+    
+/*]]>*/</script>
+<script type="text/javascript">/*<![CDATA[*/if(bbcdotcom.data.a == 1){(function(){switch(bbcdotcom.page.url){case"/":case"/default.stm":bbcdotcom.page.url=(bbcdotcom.page.edition==="domestic")?"/1/hi/default.stm":"/2/hi/default.stm";break;case"/sport":case"/sport/":case"/sport/default.stm":bbcdotcom.page.url=(bbcdotcom.page.edition==="domestic")?"/sport1/hi/default.stm":"/sport2/hi/default.stm";break}BBC.adverts.setScriptRoot("http://news.bbcimg.co.uk/js/app/bbccom/0.3.236/");bbcdotcom.config.setJsPrefix("http://news.bbcimg.co.uk/js/app/bbccom/0.3.236");bbcdotcom.config.setSwfPrefix("http://news.bbcimg.co.uk/shared/swf/bbccom/0.3.236");bbcdotcom.config.setCssPrefix("http://news.bbcimg.co.uk/css/screen/shared/0.3.236");BBC.adverts.setImgRoot("http://news.bbcimg.co.uk/shared/img/bbccom/");BBC.adverts.init({domain:bbcdotcom.page.http_host,location:bbcdotcom.page.url,zoneVersion:bbcdotcom.page.zoneFile,zoneReferrer:document.referrer})}());(function(){if(typeof require!=="undefined"){require({paths:{bbcdotcom:"http://news.bbcimg.co.uk/js/app/bbccom/0.3.236"}})}})();if(BBC.adverts.getV6Gvl3()&&"undefined"!==typeof bbcdotcom.page.bddUseLatestFromTest){document.write(unescape('%3Cscript type="text/javascript" src="http://wwwpreview.test.newsonline.tc.nca.bbc.co.uk/js/app/bbccom/'+bbcdotcom.latest_version+'/advert.js"'))}else{if(BBC.adverts.getV6Gvl3()){document.write(unescape('%3Cscript type="text/javascript" src="http://news.bbcimg.co.uk/js/app/bbccom/0.3.236/advert.js"%3E%3C/script%3E'))}}if(/[?|&]metadata=yes(&|$)/.test(window.location.search)){document.write("http://www.test.bbc.com/wwscripts/metadata?bbcdotcom_asset="+window.location.hostname+window.location.pathname)};}/*]]>*/</script>
+<script type="text/javascript">
+    /*<![CDATA[*/
+    if (BBC.adverts.isActive('analytics')) {
+        document.write(unescape('%3Cscript id="gnlAnalyticsEnabled" class="bbccom_display_none"%3E%3C/script%3E'));
+    }
+    /*]]>*/
+</script>
+
+
+    
+        
+
+<script type="text/javascript">
+	if(typeof BBC.adverts != 'undefined' && typeof BBC.adverts.setPageVersion != 'undefined'){
+		BBC.adverts.setPageVersion('(none)');
+	}
+</script>
+
+
+    
+
+        		<!-- hi/news/head_last.inc -->
+
+<script type="text/javascript">
+
+function BetaSite() {
+  function setMobileCookie() {
+    var d = new Date ();
+    d.setDate(d.getDate() + 1);
+    d = d.toUTCString();
+
+    window.bbccookies.set('ckps_d=m;domain=.bbc.co.uk;path=/;expires=' + d );
+    window.bbccookies.set('ckps_d=m;domain=.bbc.com;path=/;expires=' + d );
+  }
+
+  function isValidQueryString() {
+    return (window.location.search.indexOf('view=beta') !== -1);
+  }
+
+  function isClientCapable() {
+    return ('querySelector' in document && 'localStorage' in window && 'addEventListener' in window);
+  }
+
+  if (isClientCapable() && isValidQueryString()) {
+    setMobileCookie();
+
+    window.location.host = 'm.bbc.co.uk';
+  }
+}
+
+BetaSite();
+
+</script>
+
+
+<link rel="stylesheet" type="text/css" media="screen" href="BBC_News_Scotland_files/skin.css">
+
+
+<link rel="apple-touch-icon" href="http://news.bbcimg.co.uk/img/1_0_3/cream/hi/news/iphone.png">
+<script type="text/javascript">
+    bbcRequireMap['module/weather'] = '/inc/specials/cream/hi/news/personalisation/weather';
+    bbcRequireMap['module/local'] = '/inc/specials/cream/hi/news/personalisation';
+    bbcRequireMap['module/localnewsandweather'] = '/inc/specials/cream/hi/news/personalisation/localnewsandweather';
+    bbcRequireMap['translation'] = 'module/translations/en-GB';
+    require({ baseUrl: 'http://static.bbci.co.uk/', paths: bbcRequireMap, waitSeconds: 30 });
+</script>
+<script type="text/javascript">
+
+
+
+    
+
+
+
+
+
+
+
+
+
+
+
+    (function(){
+        var path_prefix    = "http://www.live.bbc.co.uk/nfp";
+
+        define('config', function () {
+            return {
+              "pathPrefix": path_prefix.replace('.live', ''),
+              "service": 'nfp',
+              "local": {
+                "simple": true,
+                "story_limit": 6,
+                "weather_type": "daily",
+                "append_ext": ".inc",
+                "allowAutoComplete": true,
+                "allowLocationLookup": false
+              }
+            };
+        });
+    }());
+
+
+
+require(['jquery-1'], function(jQuery) {
+    jQuery.ajaxSetup({cache: true})
+});
+
+require(["jquery-1", "istats-1"], function ($, istats) {
+    $(function() {
+        istats.track('external', {region: $('.story-body'), linkLocation : 'story-body'});
+        istats.track('external', {region: $('.story-related .related-links'), linkLocation : 'related-links'});
+        istats.track('external', {region: $('.story-related .newstracker-list'), linkLocation : 'newstracker'});
+    });
+});
+
+</script>
+
+
+
+
+
+	
+    		
+		
+	
+    	
+   
+
+<!-- CPS COMMENT STATUS: false -->
+
+
+
+
+
+
+	   <!--Rendered by NOLAPPS203-6001 -->
+	   <link rel="schema.dcterms" href="http://purl.org/dc/terms/">
+	   <meta name="DCTERMS.created" content="2010-07-05T16:02:59+00:00">
+	   <meta name="DCTERMS.modified" content="2014-03-31T13:53:03+00:00">
+    <script src="BBC_News_Scotland_files/istats-1.js" data-requiremodule="istats-1" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="BBC_News_Scotland_files/idcta-1.js" data-requiremodule="idcta/idcta-1" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="BBC_News_Scotland_files/gelui-1.js" data-requiremodule="gelui-1" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="BBC_News_Scotland_files/embed.js" data-requiremodule="http://emp.bbci.co.uk/emp/worldwide/embed.js?mediaset=journalism-pc" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="BBC_News_Scotland_files/overlay.js" data-requiremodule="gelui-1/overlay" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="BBC_News_Scotland_files/autosuggest.js" data-requiremodule="gelui-1/autosuggest" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="BBC_News_Scotland_files/carousel.js" data-requiremodule="gelui-1/carousel" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="BBC_News_Scotland_files/jssignals-1.js" data-requiremodule="jssignals-1" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="BBC_News_Scotland_files/core.js" data-requiremodule="gelui-1/core" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="BBC_News_Scotland_files/widget.js" data-requiremodule="gelui-1/widget" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><link href="BBC_News_Scotland_files/overlay.css" rel="stylesheet" type="text/css"><script src="BBC_News_Scotland_files/jcarousel-1.js" data-requiremodule="jcarousel-1" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script><script src="BBC_News_Scotland_files/swfobject-2.js" data-requiremodule="swfobject-2" data-requirecontext="_" async="" charset="utf-8" type="text/javascript"></script></head>
+
+        	    <!--[if lte IE 6]><body class="news ie disable-wide-advert"><![endif]-->
+    <!--[if IE 7]><body class="news ie7 disable-wide-advert"><![endif]-->
+    <!--[if IE 8]><body class="news ie8 disable-wide-advert"><![endif]-->
+    <!--[if !IE]>--><body class="news disable-wide-advert glow177-gecko"><!--<![endif]-->
+	
+
+
+<div class="livestats-web-bug" id="livestats-web-bug-tag"><img alt="" id="livestats" src="BBC_News_Scotland_files/o.gif"></div>
+
+<script type="text/JavaScript">
+	var referrer = document.referrer;
+
+	var livestatsBug = "<img alt='' id='livestats' src='http://stats.bbc.co.uk/o.gif?~RS~s~RS~News~RS~t~RS~HighWeb_Index~RS~i~RS~0~RS~p~RS~99112~RS~a~RS~Domestic~RS~u~RS~/news/scotland/~RS~r~RS~"+referrer+"~RS~q~RS~~RS~z~RS~36~RS~'>";
+
+
+	document.getElementById('livestats-web-bug-tag').innerHTML = livestatsBug;
+</script>
+
+
+<noscript>
+<div class="livestats-web-bug"><img alt="" id="livestats" src="http://stats.bbc.co.uk/o.gif?~RS~s~RS~News~RS~t~RS~HighWeb_Index~RS~i~RS~0~RS~p~RS~99112~RS~a~RS~Domestic~RS~u~RS~/news/scotland/~RS~q~RS~~RS~z~RS~36~RS~"/></div>
+</noscript>
+        
+	
+    <!-- BBCDOTCOM body first include -->
+    
+
+<script type="text/javascript">BBC.adverts.write("wallpaper",false);</script>
+<script type="text/javascript">/*<![CDATA[*/BBC.adverts.wallpaperBodyTag=document.getElementsByTagName("body");BBC.adverts.wallpaperATag=document.getElementsByTagName("a");if("undefined"!=typeof BBC.adverts.wallpaperATag&&"undefined"!=typeof BBC.adverts.wallpaperATag[0]&&"undefined"!=typeof BBC.adverts.wallpaperBodyTag&&"undefined"!=typeof BBC.adverts.wallpaperBodyTag[0]&&-1!==BBC.adverts.wallpaperATag[0].href.indexOf("http://ad.doubleclick.net")){BBC.adverts.wallpaperBodyTag[0].removeChild(BBC.adverts.wallpaperATag[0])};/*]]>*/</script>
+
+
+	
+	
+
+    <!-- ISTATS -->
+
+
+
+    
+
+
+
+
+
+
+ <script type="text/javascript">/*<![CDATA[*/ bbcFlagpoles_istats = 'ON'; istatsTrackingUrl = '//sa.bbc.co.uk/bbc/bbc/s?name=news.scotland.page&cps_asset_id=10059375&page_type=index&section=scotland&app_version=6.2.180-RC3&first_pub=2010-07-05T16:02:59+00:00&last_editorial_update=2014-03-31T13:53:03+00:00&title=&comments_box=false&cps_media_type=&cps_media_state=&by_nation=&app_type=web&ml_name=SSI&ml_version=0.17.2&language=en-GB'; if (window.istats_countername) { istatsTrackingUrl = istatsTrackingUrl.replace(/([?&]name=)[^&]+/ig, '$1' + istats_countername); } (function() { if ( /\bIDENTITY=/.test(document.cookie) ) { istatsTrackingUrl += '&bbc_identity=1'; } var c = (document.cookie.match(/\bckns_policy=(\d\d\d)/)||[]).pop() || ''; istatsTrackingUrl += '&bbc_mc=' + (c? 'ad'+c.charAt(0)+'ps'+c.charAt(1)+'pf'+c.charAt(2) : 'not_set'); if ( /\bckns_policy=\d\d0/.test(document.cookie) ) { istatsTrackingUrl += '&ns_nc=1'; } var screenWidthAndHeight = 'unavailable'; if (window.screen && screen.width && screen.height) { screenWidthAndHeight = screen.width + 'x' + screen.height; } istatsTrackingUrl += ('&screen_resolution=' + screenWidthAndHeight); istatsTrackingUrl += '&blq_s=3.5&blq_r=3.5&blq_v=journalism-domestic'; })(); /*]]>*/</script>  <!-- Begin iStats 20100118 (UX-CMC 1.1009.3) --> <script type="text/javascript">/*<![CDATA[*/ (function() { window.istats || (istats = {}); var cookieDisabled = (document.cookie.indexOf('NO-SA=') != -1), hasCookieLabels = (document.cookie.indexOf('sa_labels=') != -1), hasClickThrough = /^#sa-(.*?)(?:-sa(.*))?$/.test(document.location.hash), runSitestat = !cookieDisabled && !hasCookieLabels && !hasClickThrough && !istats._linkTracked; if (runSitestat && bbcFlagpoles_istats === 'ON') { sitestat(istatsTrackingUrl); } else { window.ns_pixelUrl = istatsTrackingUrl; /* used by Flash library to track */ } function sitestat(n){var j=document,f=j.location,b="";if(j.cookie.indexOf("st_ux=")!=-1){var k=j.cookie.split(";");var e="st_ux",h=document.domain,a="/";if(typeof ns_!="undefined"&&typeof ns_.ux!="undefined"){e=ns_.ux.cName||e;h=ns_.ux.cDomain||h;a=ns_.ux.cPath||a}for(var g=0,f=k.length;g<f;g++){var m=k[g].indexOf("st_ux=");if(m!=-1){b="&"+unescape(k[g].substring(m+6))}}document.cookie=e+"=; expires="+new Date(new Date().getTime()-60).toGMTString()+"; path="+a+"; domain="+h}ns_pixelUrl=n;n=ns_pixelUrl+"&ns__t="+(new Date().getTime())+"&ns_c="+((j.characterSet)?j.characterSet:j.defaultCharset)+"&ns_ti="+escape(j.title)+b+"&ns_jspageurl="+escape(f&&f.href?f.href:j.URL)+"&ns_referrer="+escape(j.referrer);if(n.length>2000&&n.lastIndexOf("&")){n=n.substring(0,n.lastIndexOf("&")+1)+"ns_cut="+n.substring(n.lastIndexOf("&")+1,n.lastIndexOf("=")).substring(0,40)}(j.images)?new Image().src=n:j.write('<p><i'+'mg src="'+n+'" height="1" width="1" alt="" /></p>')}; })(); /*]]>*/</script> <noscript><p style="position: absolute; top: -999em;"><img src="//sa.bbc.co.uk/bbc/bbc/s?name=news.scotland.page&amp;cps_asset_id=10059375&amp;page_type=index&amp;section=scotland&amp;app_version=6.2.180-RC3&amp;first_pub=2010-07-05T16:02:59+00:00&amp;last_editorial_update=2014-03-31T13:53:03+00:00&amp;title=&amp;comments_box=false&amp;cps_media_type=&amp;cps_media_state=&amp;by_nation=&amp;app_type=web&amp;ml_name=SSI&amp;ml_version=0.17.2&amp;language=en-GB&amp;blq_s=3.5&amp;blq_r=3.5&amp;blq_v=journalism-domestic" height="1" width="1" alt="" /></p></noscript> <!-- End iStats (UX-CMC) -->   <div id="blq-global"> <noscript> <div id="blq-no-js-banner"> <p>For a better experience on your device, try our <a href="http://m.bbc.co.uk">mobile site</a>.</p> </div> </noscript> <div id="blq-pre-mast" xml:lang="en-GB"> <!-- Pre mast -->  </div> </div>  <script type="text/html" id="blq-bbccookies-tmpl"><![CDATA[ <div id="bbccookies-prompt" class="bbccookies-d"> <h2> Cookies on the BBC website </h2> <p> We use cookies to ensure that we give you the best experience on our website.<span class="bbccookies-international-message"> We also use cookies to ensure we show you advertising that is relevant to you.</span> If you continue without changing your settings, we'll assume that you are happy to receive all cookies on the BBC website. However, if you would like to, you can <a href="/privacy/cookies/managing/cookie-settings.html">change your cookie settings</a> at any time. </p> <ul> <li id="bbccookies-continue"> <button type="button" id="bbccookies-continue-button">Continue</button> </li> <li id="bbccookies-more"><a href="/privacy/cookies/bbc">Find out more</a></li></ul> </div> ]]></script> <script type="text/javascript">/*<![CDATA[*/ (function(){if(bbccookies._showPrompt()){var i=document,b=i.getElementById("blq-pre-mast"),f=i.getElementById("blq-global"),h=i.getElementById("blq-container"),c=i.getElementById("blq-bbccookies-tmpl"),a,g,e;if(b&&i.createElement){a=i.createElement("div");a.id="bbccookies";e=c.innerHTML;e=e.replace("<"+"![CDATA[","").replace("]]"+">","");a.innerHTML=e;if(f){f.insertBefore(a,b)}else{h.insertBefore(a,b)}g=i.getElementById("bbccookies-continue-button");g.onclick=function(){a.parentNode.removeChild(a);return false};bbccookies._setPolicy()}}})(); /*]]>*/</script>  <div id="blq-masthead" class="blq-clearfix blq-mast-bg-transparent-light blq-lang-en-GB blq-ltr"> <span id="blq-mast-background"><span></span></span>  <div id="blq-mast" class="blq-rst">  <div id="blq-mast-bar" class="blq-masthead-container blq-journalism-domestic"> <div id="blq-blocks"> <a href="http://www.bbc.co.uk/" hreflang="en-GB"> <abbr title="British Broadcasting Corporation" class="blq-home"> <img src="BBC_News_Scotland_files/blq-blocks_grey_alpha.png" alt="BBC" height="24" width="84"> </abbr> </a> </div> <div id="blq-acc-links"> <h2 id="page-top">Accessibility links</h2> <ul>  <li><a href="#main-content">Skip to content</a></li>  <li><a href="#blq-local-nav">Skip to local navigation</a></li>  <li><a href="http://www.bbc.co.uk/accessibility/">Accessibility Help</a></li> </ul> </div> <div id="blq-sign-in" class="blq-gel">   <div style="display: block;" id="id-status" class="blq-id-v4"> <div class="id-out id-gel"> <h2 class="blq-hide">BBC iD</h2> <a class="blq-idstatus-signin" style="width: 111px; background-position: -16px center;" href="https://ssl.bbc.co.uk/id/signin?ptrt=http://www.bbc.co.uk/news/scotland/" id="blq-idstatus-link"> <span class="id-icon"> <span></span> </span> <span id="blq-idstatus-text">Sign in</span> <span class="id-spinner"></span> <span class="blq-dropdown-arrow"> <span></span> </span> </a> </div> <div style="width: 165px;" id="id-status-nav"> <div class="id-in blq-rst"> <ul> <li> <a name="idDash" class="blq-nogo has-ptrt idDash" href="https://ssl.bbc.co.uk/id/settings"> Settings </a> </li> <li> <a name="idSignout" class="blq-nogo has-ptrt idSignout" href="https://ssl.bbc.co.uk/id/signout?ptrt=http://www.bbc.co.uk/news/scotland/"> Sign out </a> </li> </ul> </div> </div> </div>          </div> <div role="navigation" id="blq-nav"> <h2>BBC navigation</h2>     <ul id="blq-nav-main">   <li id="blq-nav-news"> <a href="http://www.bbc.co.uk/news/">News</a> </li>    <li id="blq-nav-sport"> <a href="http://www.bbc.co.uk/sport/">Sport</a> </li>    <li id="blq-nav-weather"> <a href="http://www.bbc.co.uk/weather/">Weather</a> </li>    <li id="blq-nav-iplayer"> <a href="http://www.bbc.co.uk/iplayer/">iPlayer</a> </li>    <li id="blq-nav-tv"> <a href="http://www.bbc.co.uk/tv/">TV</a> </li>    <li id="blq-nav-radio"> <a href="http://www.bbc.co.uk/radio/">Radio</a> </li>    <li id="blq-nav-more"> <a href="http://www.bbc.co.uk/a-z/">More…</a> </li>   </ul>   <div id="blq-nav-search"> <form role="search" method="get" action="http://search.bbc.co.uk/search" accept-charset="utf-8" id="blq-search-form"> <div>  <input name="go" value="toolbar" type="hidden">  <input value="http://www.bbc.co.uk/news/scotland/" name="uri" type="hidden">    <input name="scope" value="news" type="hidden">  <label for="blq-search-q" class="blq-hide">Search term:</label> <input autocomplete="off" placeholder="Search" id="blq-search-q" name="q" maxlength="128" type="text"> <button id="blq-search-btn" type="submit"><span><img src="BBC_News_Scotland_files/blq-search_grey_alpha.png" alt="Search" height="13" width="13"></span></button> </div> </form> </div>  </div> </div> </div> <div style="display: none;" id="blq-panel" class="blq-rst"> <div style="display: none;" id="blq-panel-more" class="blq-masthead-container  blq-clearfix" xml:lang="en-GB" dir="ltr"> <div class="blq-panel-container panel-paneltype-more"> <div class="panel-header"> <h2> <a href="http://www.bbc.co.uk/a-z/">  More…  </a> </h2>  <a href="http://www.bbc.co.uk/a-z/" class="panel-header-links panel-header-link">Full A-Z<span class="blq-hide"> of BBC sites</span></a>  </div> <div class="panel-component panel-links">       <ul>   <li> <a href="http://www.bbc.co.uk/cbbc/">CBBC</a> </li>    <li> <a href="http://www.bbc.co.uk/cbeebies/">CBeebies</a> </li>    <li> <a href="http://www.bbc.co.uk/comedy/">Comedy</a> </li>   </ul>  <ul>   <li> <a href="http://www.bbc.co.uk/food/">Food</a> </li>    <li> <a href="http://www.bbc.co.uk/history/">History</a> </li>    <li> <a href="http://www.bbc.co.uk/learning/">Learning</a> </li>   </ul>  <ul>   <li> <a href="http://www.bbc.co.uk/music/">Music</a> </li>    <li> <a href="http://www.bbc.co.uk/science/">Science</a> </li>    <li> <a href="http://www.bbc.co.uk/nature/">Nature</a> </li>   </ul>  <ul>   <li> <a href="http://www.bbc.co.uk/local/">Local</a> </li>    <li> <a href="http://www.bbc.co.uk/travelnews/">Travel News</a> </li>   </ul>   </div> </div> </div> <div id="blq-panel-promo" class="blq-masthead-container"></div> </div></div> <div id="blq-container-outer" class="blq-journalism-domestic blq-ltr">  <div id="blq-container" class="blq-lang-en-GB"> <div id="blq-container-inner" xml:lang="en-GB"><div style="display: none;" class="blq-reset pulse-pop" id="pulse-container"><div id="pulse-q"><p>We are always looking to improve the site and your opinions count.</p><p><strong>Do you have a few minutes to tell us what you think about this site?</strong></p></div><ul id="pulse-a" class="blq-clearfix"><li><a id="pulse-accept" href="https://ecustomeropinions.com/clients/bbc/pulse?url=http%3A%2F%2Fwww.bbc.co.uk%2Fnews%2Fscotland%2F&amp;data=yes&amp;data2=news-scotland">Yes</a></li><li id="pulse-reject-container"><a id="pulse-reject" href="#">No</a></li></ul><a href="#" id="pulse-close">x</a></div>   <div id="blq-main" class="blq-clearfix">   
+	
+
+                        		    	
+		<div class="scotland  has-no-ticker  main-content-container">
+			<div id="header-wrapper">
+
+			  
+    		      			      				  <h1 id="header">
+    			      	            <a rel="index" href="http://www.bbc.co.uk/news/"><img alt="BBC News" src="BBC_News_Scotland_files/news-blocks.gif"></a>
+    	                	            	    	            		<span class="section-title">Scotland</span>
+    	            	    	            		   		      				  </h1>
+    			  			  
+			  
+			    <div class="bbccom_advert_placeholder">
+			      <script type="text/javascript">$render("advert","advert-sponsor-section");</script>
+			    </div>
+			    <script type="text/javascript">$render("advert-post-script-load");</script>
+			  
+		                    	  				    <a href="http://feeds.bbci.co.uk/news/scotland/rss.xml" id="rss-alternative">
+    				  RSS<span class="gvl3-icon gvl3-icon-rss"> feed</span>
+    			     </a>
+                                  
+
+			  	            <div id="blq-local-nav">
+ 	            <ul id="nav" class="nav">
+                	
+        	        		                	
+        	            	<li class="first-child "><a href="http://www.bbc.co.uk/news/">Home</a></li>
+                            	
+        	        	        	
+        	            	<li><a href="http://www.bbc.co.uk/news/world/">World</a></li>
+                            	
+        	        	        	
+        	            	<li><a href="http://www.bbc.co.uk/news/uk/">UK</a></li>
+                            	
+        	        	        	
+        	            	<li><a href="http://www.bbc.co.uk/news/england/">England</a></li>
+                            	
+        	        	        	
+        	            	<li><a href="http://www.bbc.co.uk/news/northern_ireland/">N. Ireland</a></li>
+                            	
+        	        	        	
+        	        		<li class="selected"><a href="http://www.bbc.co.uk/news/scotland/">Scotland</a></li>
+        		        		                            	
+        	        	        	
+        	            	<li><a href="http://www.bbc.co.uk/news/wales/">Wales</a></li>
+                            	
+        	        	        	
+        	            	<li><a href="http://www.bbc.co.uk/news/business/">Business</a></li>
+                            	
+        	        	        	
+        	            	<li><a href="http://www.bbc.co.uk/news/politics/">Politics</a></li>
+                            	
+        	        	        	
+        	            	<li><a href="http://www.bbc.co.uk/news/health/">Health</a></li>
+                            	
+        	        	        	
+        	            	<li><a href="http://www.bbc.co.uk/news/education/">Education</a></li>
+                            	
+        	        	        	
+        	            	<li><a href="http://www.bbc.co.uk/news/science_and_environment/">Sci/Environment</a></li>
+                            	
+        	        	        	
+        	            	<li><a href="http://www.bbc.co.uk/news/technology/">Technology</a></li>
+                            	
+        	        	        	
+        	            	<li><a href="http://www.bbc.co.uk/news/entertainment_and_arts/">Entertainment &amp; Arts</a></li>
+                            </ul> 
+        
+	    	      <ul id="sub-nav" class="nav"> 
+	        	        			        	        	
+	        		            	<li class="first-child "><a href="http://www.bbc.co.uk/news/scotland/scotland_politics/">Scotland Politics</a></li>
+	            	        	        		        	
+	        		            	<li><a href="http://www.bbc.co.uk/news/scotland/scotland_business/">Scotland Business</a></li>
+	            	        	        		        	
+	        		            	<li><a href="http://www.bbc.co.uk/news/scotland/edinburgh_east_and_fife/">Edinburgh, Fife &amp; East</a></li>
+	            	        	        		        	
+	        		            	<li><a href="http://www.bbc.co.uk/news/scotland/glasgow_and_west/">Glasgow &amp; West</a></li>
+	            	        	        		        	
+	        		            	<li><a href="http://www.bbc.co.uk/news/scotland/highlands_and_islands/">Highlands &amp; Islands</a></li>
+	            	        	        		        	
+	        		            	<li><a href="http://www.bbc.co.uk/news/scotland/north_east_orkney_and_shetland/">NE, Orkney &amp; Shetland</a></li>
+	            	        	        		        	
+	        		            	<li><a href="http://www.bbc.co.uk/news/scotland/south_scotland/">South</a></li>
+	            	        	        		        	
+	        		            	<li><a href="http://www.bbc.co.uk/news/scotland/tayside_and_central/">Tayside &amp; Central</a></li>
+	            	        	      </ul> 
+	    	</div>
+
+			  
+	        </div>
+	        <!-- START CPS_SITE CLASS: domestic -->
+	        <div id="content-wrapper" class="domestic">
+
+					<div class="advert">
+													
+							<div class="bbccom_advert_placeholder">
+								<script type="text/javascript">$render("advert","advert-leaderboard");</script>
+							</div>
+							<script type="text/javascript">$render("advert-post-script-load");</script>
+							
+											</div>
+                                            <div id="bbccom_custom_branding">
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        if(typeof bbcdotcom.objects('bbcdotcom.branding.init') === 'function') {
+            bbcdotcom.branding.init(BBC.adverts.getZoneData().zone, BBC.adverts.getAdKeyword());
+            bbcdotcom.branding.write();
+        }
+        /*]]>*/
+    </script>
+	<div class="bbccom_advert_placeholder">
+    <script type="text/javascript">
+        /*<![CDATA[*/
+        $render("advert","advert-sponsor-subsection");
+        /*]]>*/
+    </script>
+</div>
+</div>
+<script type="text/javascript">
+        /*<![CDATA[*/
+	$render("advert-post-script-load");
+        /*]]>*/
+</script>
+                    
+	            <!-- START CPS_SITE CLASS: index -->
+	            <div id="main-content" class="index blq-clearfix">
+			<!-- No EWA -->
+
+
+
+	
+<div id="full-width" class="container-full-width">
+	<div class="index-date">
+    <span class="date">31 March 2014</span>
+<span class="time-text">Last updated at </span><span class="time">14:53</span>
+	
+</div>
+
+	<div id="full-width-include" class="include-only special-event-promotion-full-width">
+    	
+</div>
+<script type="text/javascript">$render("full-width-include","full-width-include");</script> 
+</div>
+<script type="text/javascript">$render("container-full-width","full-width");</script> 
+	
+<div id="now" class="container-now">
+	
+<div id="container-top-stories-with-splash" class="container-top-stories">
+	
+
+  
+  
+  
+  
+  <div id="top-story" class="large-image">
+          
+                <h2 class="top-story-header ">
+      <a class="story" rel="published-1396263959196" href="http://www.bbc.co.uk/news/uk-scotland-glasgow-west-26818852">
+      Australian firm to create 110 jobs<img src="BBC_News_Scotland_files/_73924044_73921422.jpg" alt="Clough graphic"></a>
+    </h2>
+        
+        <p>An Australian firm which services the energy, chemical and 
+mining sectors is to open a base in Scotland, creating 110 new jobs.    
+	
+        <span id="dna-comment-count___CPS__26818852" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+              <hr>
+   </div>
+   <script type="text/javascript">$render("top-story","top-story");</script>
+
+	
+  
+  
+  
+  
+  
+    
+  <div id="second-story" class="secondary-top-story">
+
+                    <div class="large-image">
+                    
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h2 class=" secondary-story-header">
+	<a class="story" rel="published-1396257853848" href="http://www.bbc.co.uk/sport/0/football/26817253"><img src="BBC_News_Scotland_files/_73921211_9789351.jpg" alt="Hearts won Sunday's Edinburgh derby 2-0">Hearts in fight to stay afloat</a>
+
+		</h2>
+
+
+        <p>Hearts face the prospect of running out of money by the end 
+of April if a deal to take the club out of administration is not agreed 
+soon. 		  <a class="from-external-source" href="http://www.bbc.co.uk/sport/0/">BBC Sport</a>
+	
+        <span id="dna-comment-count___CPS__26817253" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+
+             </div>
+       </div>
+  <script type="text/javascript">$render("secondary-top-story","second-story");</script>
+
+
+
+	
+  
+  
+  
+  
+  
+    
+  <div id="third-story" class="secondary-top-story">
+
+                    <div class="large-image">
+                    
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h2 class=" secondary-story-header">
+	<a class="story" rel="published-1396224468575" href="http://www.bbc.co.uk/news/uk-scotland-glasgow-west-26809706"><img src="BBC_News_Scotland_files/_73909989_sthelena.jpg" alt="Primary school pupil with the Queen's baton in St Helena">Email error on Queen's Baton bearers</a>
+
+		</h2>
+
+
+        <p>Blank emails are sent to some people waiting to find out 
+whether they have been chosen to carry the Queen's Baton before the 
+Commonwealth Games. 	
+        <span id="dna-comment-count___CPS__26809706" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+
+              <ul class="see-also">
+
+                
+        
+                              
+                              
+          
+          
+
+
+
+
+	
+
+
+	
+
+
+
+
+<li class=" first-child column-1">
+	<a class="story" rel="published-1362999629235" href="http://www.bbc.co.uk/news/uk-scotland-glasgow-west-21715076">Glasgow 2014: Queen's Baton Relay route</a>
+
+					
+	</li>
+
+                </ul>
+             </div>
+       </div>
+  <script type="text/javascript">$render("secondary-top-story","third-story");</script>
+
+
+
+	
+
+
+
+
+												
+				
+																							
+																					
+																					
+																					
+																					
+																					
+																					
+																					
+																					
+																					
+																					
+																					
+									
+			
+			
+
+												
+				
+																					
+				
+																							
+																					
+																					
+																					
+																					
+																					
+																					
+																					
+																					
+																					
+																					
+									
+			
+			
+
+												
+				
+																					
+				
+																					
+				
+																							
+																					
+																					
+																					
+																					
+																					
+																					
+																					
+																					
+																					
+									
+		
+			
+							
+			
+							
+		
+<div id="other-top-stories" class="other-top-stories">
+			
+	<ul class="other-top-stories-stories">
+
+				  	
+												
+							
+																				
+				<li class="column-1 with-summary  first-child">
+
+                              					
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h2>
+	<a class="story" rel="published-1396270342949" href="http://www.bbc.co.uk/news/uk-scotland-glasgow-west-26822671">Appeal over missing sex offender</a>
+
+		</h2>
+
+																	
+											<p>Police appeal for help in tracing a registered sex offender in Glasgow after he failed to turn up at court. 	
+						<span id="dna-comment-count___CPS__26822671" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+									</li>
+							  	
+									
+							
+																				
+				<li class="column-1 with-summary ">
+
+                              					
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h2>
+	<a class="story" rel="published-1396254065307" href="http://www.bbc.co.uk/news/uk-scotland-north-east-orkney-shetland-26817350">Tributes to mother killed in crash</a>
+
+		</h2>
+
+																	
+											<p>Tribute is paid by relatives to a "wonderful" 28-year-old mother who was killed in a crash on the A96 in Moray. 	
+						<span id="dna-comment-count___CPS__26817350" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+									</li>
+							  	
+									
+							
+																				
+				<li class="column-1 with-summary ">
+
+                              					
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h2>
+	<a class="story" rel="published-1396223037169" href="http://www.bbc.co.uk/news/uk-scotland-26809698">RSPB in climate change action call</a>
+
+		</h2>
+
+																	
+											<p>RSPB Scotland calls for more action on climate change 
+after a report suggests it is having a big impact on some species and 
+habitats. 	
+						<span id="dna-comment-count___CPS__26809698" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+									</li>
+							  	
+									
+							
+																
+				<li class="column-2 ">
+
+                    					
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h2>
+	<a class="story" rel="published-1396223286998" href="http://www.bbc.co.uk/news/uk-scotland-scotland-business-26784889">Construction bosses 'more confident'</a>
+
+	<span id="dna-comment-count___CPS__26784889" class="gvl3-icon gvl3-icon-comment comment-count"></span>				
+	</h2>
+
+																	
+									</li>
+							  	
+									
+							
+																
+				<li class="column-2 ">
+
+                    					
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h2>
+	<a class="story" rel="published-1396258447212" href="http://www.bbc.co.uk/news/uk-scotland-glasgow-west-26818850">Woman dies after Bearsden road crash</a>
+
+	<span id="dna-comment-count___CPS__26818850" class="gvl3-icon gvl3-icon-comment comment-count"></span>				
+	</h2>
+
+																	
+									</li>
+							  	
+									
+							
+																
+				<li class="column-2 ">
+
+                    					
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h2>
+	<a class="story" rel="published-1396266982108" href="http://www.bbc.co.uk/news/uk-scotland-north-east-orkney-shetland-26817356">Former So Solid Crew member fined</a>
+
+	<span id="dna-comment-count___CPS__26817356" class="gvl3-icon gvl3-icon-comment comment-count"></span>				
+	</h2>
+
+																	
+									</li>
+							  	
+									
+							
+																
+				<li class="column-2 ">
+
+                    					
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h2>
+	<a class="story" rel="published-1396268477121" href="http://www.bbc.co.uk/news/uk-scotland-highlands-islands-26821234">Skiing until end of April 'possible'</a>
+
+	<span id="dna-comment-count___CPS__26821234" class="gvl3-icon gvl3-icon-comment comment-count"></span>				
+	</h2>
+
+																	
+									</li>
+							  	
+									
+							
+																
+				<li class="column-2 ">
+
+                    					
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h2>
+	<a class="story" rel="published-1396262674922" href="http://www.bbc.co.uk/news/uk-scotland-glasgow-west-26819151">Festival to pay tribute to Iain Banks</a>
+
+	<span id="dna-comment-count___CPS__26819151" class="gvl3-icon gvl3-icon-comment comment-count"></span>				
+	</h2>
+
+																	
+									</li>
+							  	
+									
+							
+																
+				<li class="column-2 ">
+
+                    					
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h2>
+	<a class="story" rel="published-1396223668919" href="http://www.bbc.co.uk/news/uk-scotland-edinburgh-east-fife-26813170">Panda mating preparations begin</a>
+
+	<span id="dna-comment-count___CPS__26813170" class="gvl3-icon gvl3-icon-comment comment-count"></span>				
+	</h2>
+
+																	
+									</li>
+							  	
+									
+							
+																
+				<li class="column-2 ">
+
+                    					
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h2>
+	<a class="story" rel="published-1396270258777" href="http://www.bbc.co.uk/news/business-26820844">Scottish farm incomes 'fell by 34%'</a>
+
+	<span id="dna-comment-count___CPS__26820844" class="gvl3-icon gvl3-icon-comment comment-count"></span>				
+	</h2>
+
+																	
+									</li>
+							  	
+									
+							
+																
+				<li class="column-2 ">
+
+                    					
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h2>
+	<a class="story" rel="published-1396265702158" href="http://www.bbc.co.uk/news/uk-scotland-north-east-orkney-shetland-26817357">Asbo-style notice for wind farm</a>
+
+	<span id="dna-comment-count___CPS__26817357" class="gvl3-icon gvl3-icon-comment comment-count"></span>				
+	</h2>
+
+																	
+									</li>
+							  	
+									
+							
+																
+				<li class="column-2 ">
+
+                    					
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h2>
+	<a class="story" rel="published-1396255144943" href="http://www.bbc.co.uk/news/uk-scotland-highlands-islands-26817523">Armed robbery at city betting shop</a>
+
+	<span id="dna-comment-count___CPS__26817523" class="gvl3-icon gvl3-icon-comment comment-count"></span>				
+	</h2>
+
+																	
+									</li>
+							  	
+									
+							
+																
+				<li class="column-2 ">
+
+                    					
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h2>
+	<a class="story" rel="published-1396265299461" href="http://www.bbc.co.uk/news/uk-scotland-scotland-politics-26819160">Scottish SPCA could get new powers</a>
+
+	<span id="dna-comment-count___CPS__26819160" class="gvl3-icon gvl3-icon-comment comment-count"></span>				
+	</h2>
+
+																	
+									</li>
+						</ul>
+</div>
+<script type="text/javascript">$render("other-top-stories","other-top-stories");</script>
+
+</div>
+<script type="text/javascript">$render("container-top-stories","container-top-stories-with-splash");</script> 
+	
+			
+	<div id="also-in-the-news" class="also-in-news">
+					<h2 class="also-in-news-header">Also In The News</h2>
+			
+		<ul>
+					
+										
+					
+									
+			
+							<li class="small-image column-1 first-child">
+
+					
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h3>
+	<a class="story" rel="published-1396266463348" href="http://www.bbc.co.uk/news/uk-scotland-glasgow-west-26817726"><img src="BBC_News_Scotland_files/_73924867_177533960.jpg" alt="TV studio">Glasgow TV channel to launch in June</a>
+
+					
+	</h3>
+
+				</li>
+						
+			
+					
+										
+					
+						
+			
+							<li class="small-image column-2 ">
+
+					
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h3>
+	<a class="story" rel="published-1396261698130" href="http://www.bbc.co.uk/news/uk-scotland-tayside-central-26819000"><img src="BBC_News_Scotland_files/_73922520_00408cf54880_31-03-2014_07-22-54.jpg" alt="Lady the osprey">'Oldest breeding osprey' returns</a>
+
+					
+	</h3>
+
+				</li>
+						
+			
+				</ul>
+		
+	</div>
+	<script type="text/javascript">$render("also-in-news","also-in-the-news");</script>
+
+	
+
+
+
+
+
+		  				<h2 class="geo-digest-solo-header">More news from around Scotland</h2>
+				
+	<div class="container-geographic-regions-generic ">
+			
+			
+	<div id="geo-scotland-news-digest" class="geo-digest-region   ">
+	
+		
+							
+								
+					
+									
+								
+								
+								
+								
+								
+			
+			<div class="include-wrapper column-2">
+	<div id="scotland-map"></div>
+</div>
+		
+				
+									
+						
+					
+
+
+
+<div class="geo-digest-section column-1 ">
+	   	
+        <h4 class="geo-digest-section-header"><a class="story" href="http://www.bbc.co.uk/news/scotland/edinburgh_east_and_fife/">Edinburgh, Fife &amp; East </a>
+               </h4>
+   
+   
+   <ul>
+   	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396224652753" href="http://www.bbc.co.uk/news/uk-scotland-edinburgh-east-fife-26786483">Altitude sickness 'two illnesses'</a>
+
+					
+	</li>
+
+  	 	  	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396257164391" href="http://www.bbc.co.uk/news/uk-scotland-edinburgh-east-fife-26817846">Remains confirmed as missing woman</a>
+
+					
+	</li>
+
+  	 	  	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396188849503" href="http://www.bbc.co.uk/news/uk-scotland-edinburgh-east-fife-26810876">Fatal crash victim named by police</a>
+
+					
+	</li>
+
+  	 	  	   </ul>
+</div>
+
+									
+						
+					
+
+
+
+<div class="geo-digest-section column-1 ">
+	   	
+        <h4 class="geo-digest-section-header"><a class="story" href="http://www.bbc.co.uk/news/scotland/glasgow_and_west/">Glasgow &amp; West</a>
+               </h4>
+   
+   
+   <ul>
+   	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396266681502" href="http://www.bbc.co.uk/news/uk-scotland-glasgow-west-26818856">Police name man who died in crash</a>
+
+					
+	</li>
+
+  	 	  	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396266748664" href="http://www.bbc.co.uk/news/uk-scotland-glasgow-west-26818853">Drug trafficker to lose £214,000</a>
+
+					
+	</li>
+
+  	 	  	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396223087266" href="http://www.bbc.co.uk/news/magazine-26784218">Grant Morrison and Rian Hughes: The story behind 'The Key'</a>
+
+					
+	</li>
+
+  	 	  	   </ul>
+</div>
+
+									
+						
+					
+
+
+
+<div class="geo-digest-section column-1 ">
+	   	
+        <h4 class="geo-digest-section-header"><a class="story" href="http://www.bbc.co.uk/news/scotland/highlands_and_islands/">Highlands &amp; Islands</a>
+               </h4>
+   
+   
+   <ul>
+   	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396264053634" href="http://www.bbc.co.uk/news/uk-scotland-highlands-islands-26817532">Flybe looks at Inverness-London link</a>
+
+					
+	</li>
+
+  	 	  	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396168790221" href="http://www.bbc.co.uk/news/uk-scotland-highlands-islands-26808335">Climber dies after Ben Nevis fall</a>
+
+					
+	</li>
+
+  	 	  	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396062035656" href="http://www.bbc.co.uk/news/magazine-26646648">Meet the aurora hunters</a>
+
+					
+	</li>
+
+  	 	  	   </ul>
+</div>
+
+									
+						
+					
+
+
+
+<div class="geo-digest-section column-1 ">
+	   	
+        <h4 class="geo-digest-section-header"><a class="story" href="http://www.bbc.co.uk/news/scotland/north_east_orkney_and_shetland/">North East, Orkney &amp; Shetland</a>
+               </h4>
+   
+   
+   <ul>
+   	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396267930233" href="http://www.bbc.co.uk/news/uk-scotland-scotland-business-26820748">Ithaca Energy profits rise to £87m</a>
+
+					
+	</li>
+
+  	 	  	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396271583799" href="http://www.bbc.co.uk/news/uk-scotland-tayside-central-26819725">New £2.5m rig base for Dundee port</a>
+
+					
+	</li>
+
+  	 	  	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396018957956" href="http://www.bbc.co.uk/news/uk-scotland-north-east-orkney-shetland-26790169">Fans 'swear at own team' on Twitter</a>
+
+					
+	</li>
+
+  	 	  	   </ul>
+</div>
+
+									
+								
+					
+
+
+
+<div class="geo-digest-section column-2 column-top">
+	   	
+        <h4 class="geo-digest-section-header"><a class="story" href="http://www.bbc.co.uk/news/scotland/south_scotland/">South Scotland</a>
+               </h4>
+   
+   
+   <ul>
+   	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396268083608" href="http://www.bbc.co.uk/news/uk-scotland-south-scotland-26821780">Ice hockey event nets revenue boost</a>
+
+					
+	</li>
+
+  	 	  	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396224023029" href="http://www.bbc.co.uk/news/uk-scotland-south-scotland-26787316">Bypass cuts risk of 'bridge strikes'</a>
+
+					
+	</li>
+
+  	 	  	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396224209908" href="http://www.bbc.co.uk/news/uk-scotland-scotland-business-26766606">Tyre firm looks to fund expansion</a>
+
+					
+	</li>
+
+  	 	  	   </ul>
+</div>
+
+									
+						
+					
+
+
+
+<div class="geo-digest-section column-2 ">
+	   	
+        <h4 class="geo-digest-section-header"><a class="story" href="http://www.bbc.co.uk/news/scotland/tayside_and_central/">Tayside &amp; Central</a>
+               </h4>
+   
+   
+   <ul>
+   	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1396265993948" href="http://www.bbc.co.uk/news/uk-scotland-tayside-central-26819717">Drunk teen tried to ram police car</a>
+
+					
+	</li>
+
+  	 	  	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1395819536244" href="http://www.bbc.co.uk/news/uk-scotland-26744672">Scaling back the many-headed Hydro</a>
+
+					
+	</li>
+
+  	 	  	   		  	 		
+
+
+
+
+	
+
+
+		
+
+
+
+
+<li>
+	<a class="story" rel="published-1395401126525" href="http://www.bbc.co.uk/news/uk-scotland-tayside-central-26681537">Escaped police dog sparks search</a>
+
+					
+	</li>
+
+  	 	  	   </ul>
+</div>
+
+				
+	</div>
+	</div>
+
+
+	<div id="correspondent-strapline" class="generic-include-container correspondent-promotion-now">
+    	 	<h2 class="top-level-heading"><a href="http://www.bbc.co.uk/news/correspondents/douglasfraser/">Our Experts</a></h2>
+		
+			<div class="correspondent-promo">
+	<div class="correspondent-promo-inner">
+		<a href="http://www.bbc.co.uk/news/correspondents/briantaylor">
+			<span class="correspondent-portrait"><img src="BBC_News_Scotland_files/_58403028_97e82173-3495-4540-b671-f1464030139c.jpg" alt="Brian Taylor, Political editor, Scotland" height="104" width="144"></span>
+			<span class="promo-lead-in">Article written by  Brian Taylor</span>
+			<span class="name">Brian Taylor</span>
+		</a>
+		<span class="bbc-role">Political editor, Scotland</span>
+		<ul class="social-links">
+			<li><a rel="me" href="http://www.bbc.co.uk/news/correspondents/briantaylor">More from Brian</a></li>
+			
+		</ul>
+		
+
+        
+    <div class="correspondent-promo-item">
+                
+        <div class="article blog pinned">
+            <h2><a href="http://www.bbc.co.uk/news/uk-scotland-26800420">Contest of doubt and reassurance </a></h2>
+            <p class="article-date">11:47 UK time, Saturday, 29 March 2014</p>
+            <p>Does it matter that an unnamed minister of unknown status
+ follows an undiscernible motivation and gives an off-the-record comment
+ to The Guardian? Frankly, yes it does.  </p>
+            <p>
+                <a href="http://www.bbc.co.uk/news/uk-scotland-26800420">                    
+                                                Read full article                                        </a>
+            </p>
+        </div>
+        
+                
+    </div>
+
+
+
+
+	</div>
+</div>
+
+			<div class="correspondent-promo">
+	<div class="correspondent-promo-inner">
+		<a href="http://www.bbc.co.uk/news/correspondents/douglasfraser">
+			<span class="correspondent-portrait"><img src="BBC_News_Scotland_files/_58405014_4290d1a0-7725-4113-a5e1-a14e4c5885c3.jpg" alt="Douglas Fraser, Business and economy editor, Scotland" height="104" width="144"></span>
+			<span class="promo-lead-in">Article written by  Douglas Fraser</span>
+			<span class="name">Douglas Fraser</span>
+		</a>
+		<span class="bbc-role">Business and economy editor, Scotland</span>
+		<ul class="social-links">
+			<li><a rel="me" href="http://www.bbc.co.uk/news/correspondents/douglasfraser">More from Douglas</a></li>
+			
+		</ul>
+		
+
+        
+    <div class="correspondent-promo-item">
+                
+        <div class="article blog pinned">
+            <h2><a href="http://www.bbc.co.uk/news/uk-scotland-26815714">Has Scotland ‘de-globalised’? </a></h2>
+            <p class="article-date">8 hours ago</p>
+            <p>As Scotland looks to a choice on its future, two academic
+ contributions give us a new take on the economic route that got us to 
+where we are now.</p>
+            <p>
+                <a href="http://www.bbc.co.uk/news/uk-scotland-26815714">                    
+                                                Read full article                                        </a>
+            </p>
+        </div>
+        
+                
+    </div>
+
+
+
+
+	</div>
+</div>
+
+	</div>
+<script type="text/javascript">$render("correspondent-strapline","correspondent-strapline");</script>
+	
+<div id="special-reports" class="special-reports-component">
+    
+  <h2 class="special-reports-header">
+          	<a href="http://www.bbc.co.uk/news/16630456">Special Reports</a>
+        </h2>
+  
+
+  <div class="special-reports-wrapper">
+		  
+	  		  		
+	  		
+	  		
+	  		<div class="top-report">
+		      
+	 		  
+
+
+
+
+
+
+
+
+
+
+
+
+<h3>
+	<a class="story" rel="published-1358350237871" href="http://www.bbc.co.uk/news/16630456"><img src="BBC_News_Scotland_files/_69185589_flags4.jpg" alt="Saltire and union flags">Scotland's Future</a>
+
+		</h3>
+
+			  	<p>Latest news, background and analysis on the referendum on Scottish independence</p>
+			  	
+				
+				<div class="bbccom_advert_placeholder">
+					<script type="text/javascript">$render("advert","advert-sponsor-module","special-reports","scotlands-future");</script>
+				</div>
+				<script type="text/javascript">$render("advert-post-script-load");</script>
+				 
+	 		</div>
+  			  		  
+	  	  			  			<div class="more-special-reports">
+  			  <h3 class="more">More Special Reports:</h3>
+  			  <ul>
+  			  				<li>
+  					
+
+
+
+
+
+
+
+
+
+
+
+
+<h4>
+	<a class="story" rel="published-1381312793289" href="http://www.bbc.co.uk/news/world-24733934">Queen's Baton Relay</a>
+
+		</h4>
+
+				</li>
+  			
+  			  			  </ul>
+  			  </div>
+			  			  	  </div>
+  
+</div>
+<script type="text/javascript">$render("special-reports","special-reports");</script> 
+
+
+	
+<div id="category-digests" class="container-category-digests digest-multiple">
+	
+			<h2 class="digest-wrapper-header">More from Scotland</h2>
+	
+			
+								
+						
+		
+
+
+
+<div class="digest  first-child">
+	
+			<h3 class="digest-header"><a href="http://www.bbc.co.uk/news/scotland/scotland_politics/">Politics</a></h3>
+	  	
+  	<ul>
+  		  			
+  			  			
+  			  								  				
+  				<li class="medium-image first-child">
+	 				
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h4 class=" digest-story-header">
+	<a class="story" rel="published-1396155748874" href="http://www.bbc.co.uk/news/uk-scotland-26807255"><img src="BBC_News_Scotland_files/_73910280_carmichael_pa.jpg" alt="Alistair Carmichael">Scottish Yes vote 'not impossible'</a>
+
+		</h4>
+
+	 				
+	 					 					<p>It is "absolutely the case" that the Yes campaign could 
+win the independence referendum, Scottish Secretary Alistair Carmichael 
+warns.</p>
+	 					 				<hr>
+	  			</li>
+
+  			  		  			
+  			  			
+  				  			
+	  				  				  			  			
+	 			<li class="column-1">
+	 				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h4 class=" digest-story-header">
+	<a class="story" rel="published-1396053207489" href="http://www.bbc.co.uk/news/uk-scotland-scotland-politics-26791759">Rennie critical of justice overhaul</a>
+
+		</h4>
+
+	  			</li>
+  			  		  			
+  			  			
+  				  			
+	  				  				  			  			
+	 			<li class="column-2">
+	 				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h4 class=" digest-story-header">
+	<a class="story" rel="published-1396137694358" href="http://www.bbc.co.uk/news/uk-scotland-26803331">Dentists to be given defibrillators</a>
+
+		</h4>
+
+	  			</li>
+  			  		 	</ul>
+</div>
+
+			
+						
+						
+		
+
+
+
+<div class="digest  ">
+	
+			<h3 class="digest-header"><a href="http://www.bbc.co.uk/news/scotland/scotland_business/">Business</a></h3>
+	  	
+  	<ul>
+  		  			
+  			  			
+  			  								  				
+  				<li class="medium-image first-child">
+	 				
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h4 class=" digest-story-header">
+	<a class="story" rel="published-1396223830934" href="http://www.bbc.co.uk/news/uk-scotland-scotland-business-26810879"><img src="BBC_News_Scotland_files/_73913572_176640491.jpg" alt="Office desk">Small firms split over independence</a>
+
+		</h4>
+
+	 				
+	 					 					<p>Scotland's small business owners are divided over the possible implications of independence, a survey has suggested.</p>
+	 					 				<hr>
+	  			</li>
+
+  			  		  			
+  			  			
+  				  			
+	  				  				  			  			
+	 			<li class="column-1">
+	 				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h4 class=" digest-story-header">
+	<a class="story" rel="published-1396243904074" href="http://www.bbc.co.uk/news/uk-scotland-26812504">Experts discuss young workforce plan</a>
+
+		</h4>
+
+	  			</li>
+  			  		  			
+  			  			
+  				  			
+	  				  				  			  			
+	 			<li class="column-2">
+	 				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h4 class=" digest-story-header">
+	<a class="story" rel="published-1396042706378" href="http://www.bbc.co.uk/news/uk-scotland-scotland-politics-26791763">Osborne denies currency deal claim</a>
+
+		</h4>
+
+	  			</li>
+  			  		 	</ul>
+</div>
+
+			
+						
+						
+		
+
+
+
+<div class="digest  ">
+	
+			<h3 class="digest-header"><a href="http://www.bbc.co.uk/sport1/hi/scotland/default.stm">Sport</a></h3>
+	  	
+  	<ul>
+  		  			
+  			  			
+  			  								  				
+  				<li class="medium-image first-child">
+	 				
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h4 class=" digest-story-header">
+	<a class="story" rel="published-1396266373324" href="http://www.bbc.co.uk/sport/0/football/26821335"><img src="BBC_News_Scotland_files/_73925590_6101831.jpg" alt="Craig Gordon last played for Scotland in November 2010">Gordon eyes return for Scotland</a>
+
+		</h4>
+
+	 				
+	 					 					<p>Scotland goalkeeper Craig Gordon is looking forward to reviving his career after two years on the sidelines through injury.</p>
+	 					 				<hr>
+	  			</li>
+
+  			  		  			
+  			  			
+  				  			
+	  				  				  			  			
+	 			<li class="column-1">
+	 				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h4 class=" digest-story-header">
+	<a class="story" rel="published-1396248538845" href="http://www.bbc.co.uk/sport/0/golf/26800602">Masters dream debut for Gallacher</a>
+
+		</h4>
+
+	  			</li>
+  			  		  			
+  			  			
+  				  			
+	  				  				  			  			
+	 			<li class="column-2">
+	 				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h4 class=" digest-story-header">
+	<a class="story" rel="published-1396261211982" href="http://www.bbc.co.uk/sport/0/football/26819868">Bolton extend Hutton loan deal</a>
+
+		</h4>
+
+	  			</li>
+  			  		 	</ul>
+</div>
+
+			
+						
+						
+		
+
+
+
+<div class="digest  ">
+	
+			<h3 class="digest-header"><a href="http://www.bbc.co.uk/naidheachdan/">Naidheachdan</a></h3>
+	  	
+  	<ul>
+  		  			
+  			  			
+  			  								  				
+  				<li class="medium-image first-child">
+	 				
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h4 class=" digest-story-header">
+	<a class="story" rel="published-1396259651220" href="http://www.bbc.co.uk/naidheachdan/26785718"><img src="BBC_News_Scotland_files/_73921983_bookies.jpg" alt="Càr poilis ann an Inbhir Nis">Mèirle le gunna an Inbhir Nis ga rannsachadh</a>
+
+		</h4>
+
+	 				
+	 					 					<p>Poilis ann an Inbhir Nis a' sireadh fear a rinn mèirle le gunna ann am bùth gheall sa bhaile.</p>
+	 					 				<hr>
+	  			</li>
+
+  			  		  			
+  			  			
+  				  			
+	  				  				  			  			
+	 			<li class="column-1">
+	 				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h4 class=" digest-story-header">
+	<a class="story" rel="published-1396255651694" href="http://www.bbc.co.uk/naidheachdan/26817704">Fireannach air bàsachadh air Beinn Nibheis</a>
+
+		</h4>
+
+	  			</li>
+  			  		  			
+  			  			
+  				  			
+	  				  				  			  			
+	 			<li class="column-2">
+	 				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h4 class=" digest-story-header">
+	<a class="story" rel="published-1396002222272" href="http://www.bbc.co.uk/naidheachdan/26783316">Obair gus tòiseachadh air camarathan an A9</a>
+
+		</h4>
+
+	  			</li>
+  			  		 	</ul>
+</div>
+
+	</div>
+<script type="text/javascript">$render("container-generic-digests","category-digests");</script>
+
+	
+<div id="featured-other-site" class="container-featured-other-site">
+ 	<h2 class="container-featured-other-site-heading"><a href="http://www.bbc.co.uk/democracylive/scotland/">Democracy Live</a></h2>
+	
+<div id="featured-site-top-stories" class="featured-site-top-stories">
+
+	
+	<ul>
+			
+													
+					
+						
+		<li class=" medium-image first-child">
+
+			
+
+
+
+
+		
+
+
+		
+
+
+
+
+<h3>
+	<a class="story" rel="published-1395926962010" href="http://www.bbc.co.uk/democracylive/scotland-26759524"><img src="BBC_News_Scotland_files/_73851791_73849714.jpg" alt="First Minister Alex Salmond">Scottish Parliament<span class="gvl3-icon-wrapper"><span class="gvl3-icon gvl3-icon-invert-watch"> Watch</span></span></a>
+
+		</h3>
+
+			
+						  <p>Alex Salmond welcomes the 'big six' energy firms having to face a competition inquiry.</p>
+						
+			
+			
+						
+						  <hr>
+					</li>
+	
+		</ul>
+</div>
+<script type="text/javascript">$render("featured-site-top-stories","featured-site-top-stories");</script> 
+
+	<div id="featured-site-include-2" class="include-only featured-site-include">
+    	<div id="find-a-representative" class="find-a-representative">
+
+<div class="content-object-34">        
+        <h2>Find a representative</h2>                                            
+       	<div class="content-container">       		
+       		<form id="content-object-34-form" method="get" action="http://news.bbc.co.uk/democracylive/hi/representatives/search">        	                       
+	    	    <fieldset class="content-object-34-fieldset">        	                        
+    		      	<legend><span>Search terms</span></legend>        	                        
+        	        <label class="" for="content-object-34-form-keyword">Enter the name of who you are looking for, a place or full postcode e.g. CF10 3NQ</label>
+        	        <input id="content-object-34-form-keyword" name="q" class="input" type="text">
+        	        <input id="search-type" name="type" value="representatives" type="hidden">        	                       	                             
+        	      	<input value="Search" class="submit" id="content-object-34-form-submit" type="submit">   			
+  	    	    </fieldset>        	                                                       
+    		</form>
+        </div>                
+   	</div>
+
+</div>
+<script type="text/javascript">
+$render("hide-text-input-labels","find-a-representative");
+gloader.load(["glow","1","glow.forms"],{onLoad: function(glow){new glow.forms.Form("#content-object-34-form").addTests("q", ["required"]);}});
+</script> 
+</div>
+<script type="text/javascript">$render("featured-site-include-2","featured-site-include-2");</script> 
+</div>
+<script type="text/javascript">$render("container-featured-other-site","featured-other-site");</script> 
+	
+
+
+<div id="useful-links" class="useful-links ">
+		 	<h2 class="useful-links-header"><a href="http://www.bbc.co.uk/scotland/">From BBC Scotland</a></h2>
+		<ul>
+				  	
+												
+									
+												
+			<li class="column-1  first-child column-top">
+
+				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h3>
+	<a class="story" href="http://www.bbc.co.uk/radioscotland/">Radio Scotland</a>
+
+		</h3>
+
+			</li>
+	
+				  	
+									
+									
+									
+			<li class="column-1  ">
+
+				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h3>
+	<a class="story" href="http://www.bbc.co.uk/alba/">BBC Alba</a>
+
+		</h3>
+
+			</li>
+	
+				  	
+									
+									
+									
+			<li class="column-1  ">
+
+				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h3>
+	<a class="story" href="http://www.bbc.co.uk/radionangaidheal/">Radio nan Gàidheal</a>
+
+		</h3>
+
+			</li>
+	
+				  	
+									
+									
+									
+			<li class="column-1  ">
+
+				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h3>
+	<a class="story" href="http://www.bbc.co.uk/scotland/learning/">Learning Scotland</a>
+
+		</h3>
+
+			</li>
+	
+				  	
+									
+												
+												
+			<li class="column-2  column-top">
+
+				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h3>
+	<a class="story" href="http://www.bbc.co.uk/alba/ceol/">Ceòl/Music</a>
+
+		</h3>
+
+			</li>
+	
+				  	
+									
+												
+									
+			<li class="column-2  ">
+
+				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h3>
+	<a class="story" href="http://www.bbc.co.uk/scotland/music/">Scotland's Music</a>
+
+		</h3>
+
+			</li>
+	
+				  	
+									
+												
+									
+			<li class="column-2  ">
+
+				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h3>
+	<a class="story" href="http://www.bbc.co.uk/scotland/landscapes/">Scotland's Landscape</a>
+
+		</h3>
+
+			</li>
+	
+				  	
+									
+												
+									
+			<li class="column-2  ">
+
+				
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h3>
+	<a class="story" href="http://www.bbc.co.uk/robertburns/">Robert Burns</a>
+
+		</h3>
+
+			</li>
+	
+			</ul>
+</div>
+
+
+</div>
+<script type="text/javascript">$render("container-now","now");</script> 
+	
+<div id="best" class="container-best">
+	
+<div id="promo-best" class="container-promo-best">
+	
+<div class="bbccom_advert_placeholder">
+	<script type="text/javascript">$render("advert","advert-mpu-high");</script>
+</div>
+<script type="text/javascript">$render("advert-post-script-load");</script>
+
+	
+<div id="av-best" class="container-av-best">
+	
+																
+	<div id="av-stories-best" class="av-stories-best">
+		
+					<h2 class="av-best-header">Watch/Listen</h2>
+				
+				<div class="list-wrapper">
+		  
+            		  
+		  <div class="glow177-carousel gvl3-carousel"><div class="carousel-light"><div style="width: 288px; height: 124px;" class="carousel-window paged"><ul style="width: 1152px;" class="av-best-carousel carousel  carousel-content">
+			  				  					  					  					  
+
+
+
+
+		
+
+
+		
+
+
+
+
+<li style="" class=" first-child carousel-item ">
+	<a class="story" rel="published-1396116943248" href="http://www.bbc.co.uk/news/uk-scotland-26803761"><img src="BBC_News_Scotland_files/_73902066_reverend.jpg" alt="Reverend Dr Laurence Whitley">Chaplain: 'Clutha heartache still raw'<span class="gvl3-icon-wrapper"><span class="gvl3-icon gvl3-icon-invert-watch"> Watch</span></span><span class="av-time">01:56</span></a>
+
+		</li>
+
+				  			  				  					  					  
+
+
+
+
+		
+
+
+		
+
+
+
+
+<li class="carousel-item ">
+	<a class="story" rel="published-1396020103115" href="http://www.bbc.co.uk/news/uk-scotland-scotland-politics-26787265"><img src="BBC_News_Scotland_files/_73880347_alasdairgray.jpg" alt="Alasdair Gray, author and artist">Gray on books, Yes vote and depression<span class="gvl3-icon-wrapper"><span class="gvl3-icon gvl3-icon-invert-watch"> Watch</span></span><span class="av-time">09:37</span></a>
+
+		</li>
+
+				  			  				  					  					  
+
+
+
+
+		
+
+
+		
+
+
+
+
+<li class="carousel-item not-visible">
+	<a class="story" rel="published-1396042051997" href="http://www.bbc.co.uk/schoolreport/26794757"><img src="BBC_News_Scotland_files/_73892326_01sr14weatherpackage.jpg" alt="BBC News School Report took over the Nations and Regions weather bulletins">Student forecasters present weather<span class="gvl3-icon-wrapper"><span class="gvl3-icon gvl3-icon-invert-watch"> Watch</span></span><span class="av-time">04:37</span></a>
+
+		</li>
+
+				  			  				  					  					  
+
+
+
+
+		
+
+
+		
+
+
+
+
+<li class="carousel-item not-visible">
+	<a class="story" rel="published-1396017238947" href="http://www.bbc.co.uk/news/uk-scotland-26784370"><img src="BBC_News_Scotland_files/_73881486_cluha2.jpg" alt="clutha friends">Clutha survivors talk about crash<span class="gvl3-icon-wrapper"><span class="gvl3-icon gvl3-icon-invert-watch"> Watch</span></span><span class="av-time">03:15</span></a>
+
+		</li>
+
+				  			  				  					  					  
+
+
+
+
+		
+
+
+		
+
+
+
+
+<li class="carousel-item not-visible">
+	<a class="story" rel="published-1395908103544" href="http://www.bbc.co.uk/news/business-26763495"><img src="BBC_News_Scotland_files/_73841220_73827291.jpg" alt="graphic showing the 'big six'">'Energy firms need to rebuild trust'<span class="gvl3-icon-wrapper"><span class="gvl3-icon gvl3-icon-invert-watch"> Watch</span></span><span class="av-time">02:10</span></a>
+
+		</li>
+
+				  			  				  					  					  
+
+
+
+
+		
+
+
+		
+
+
+
+
+<li class="carousel-item not-visible">
+	<a class="story" rel="published-1395912403323" href="http://www.bbc.co.uk/schoolreport/26566829"><img src="BBC_News_Scotland_files/_73703503_de30.jpg" alt="Boy on badminton court">Visiting Scotland's School of Sport<span class="gvl3-icon-wrapper"><span class="gvl3-icon gvl3-icon-invert-watch"> Watch</span></span><span class="av-time">04:10</span></a>
+
+		</li>
+
+				  			  				  					  					  
+
+
+
+
+		
+
+
+		
+
+
+
+
+<li class="carousel-item not-visible">
+	<a class="story" rel="published-1395840700543" href="http://www.bbc.co.uk/news/uk-26745169"><img src="BBC_News_Scotland_files/_73824416_73818191.jpg" alt="Richard Durkin said the ruling was a victory for the consumer">Laptop ruling 'victory for consumer'<span class="gvl3-icon-wrapper"><span class="gvl3-icon gvl3-icon-invert-watch"> Watch</span></span><span class="av-time">01:54</span></a>
+
+		</li>
+
+				  			  				  					  					  
+
+
+
+
+		
+
+
+		
+
+
+
+
+<li class="carousel-item not-visible">
+	<a class="story" rel="published-1395792551250" href="http://www.bbc.co.uk/news/magazine-26737284"><img src="BBC_News_Scotland_files/_73806716_73806589.jpg" alt="Mountain hare (c) Will Nicholls">Teen photographer's love for animals<span class="gvl3-icon-wrapper"><span class="gvl3-icon gvl3-icon-invert-watch"> Watch</span></span><span class="av-time">03:19</span></a>
+
+		</li>
+
+				  			  		  </ul></div><ul style="margin-left: 96px;" class="pageNav"><li class="arrow carousel-prev-disabled" id="leftarrow"><a href="#" class="dotLabel">previous</a></li><li class="dot dot0 dotActive"><div class="dotLabel">1</div></li><li class="dot dot1"><div class="dotLabel">2</div></li><li class="dot dot2"><div class="dotLabel">3</div></li><li class="dot dot3"><div class="dotLabel">4</div></li><li class="arrow" id="rightarrow"><a href="#" class="dotLabel">next</a></li></ul></div></div>
+		</div>
+		
+	</div>
+
+	<script type="text/javascript">$render("av-stories-best","av-stories-best");</script>
+
+
+	
+<div id="av-live-streams" class="av-live-streams">
+	
+			  	
+						
+									<ul>
+													
+				
+			<li class=" first-child">
+
+				
+
+
+
+
+		
+
+
+	
+
+
+
+
+<h3 class="has-icon-boxedlive ">
+	<a class="story is-live" rel="published-1278944851948" href="http://www.bbc.co.uk/news/10318089">BBC News Channel<span class="gvl3-icon gvl3-icon-boxedlive"> Live</span></a>
+
+		</h3>
+
+			</li>
+				  	
+				
+							
+				
+			<li>
+
+				
+
+
+
+
+		
+
+
+	
+
+
+
+
+<h3 class="has-icon-boxedlive ">
+	<a class="story is-live" rel="published-1279810521521" href="http://news.bbc.co.uk/1/hi/help/7277283.stm" onclick="javascript: void window.open('http://www.bbc.co.uk/iplayer/console/bbc_radio_scotland', 'BBC', 'toolbar=0,scrollbars=0,location=0,statusbar=0,menubar=0,resizable=0,width=512,height=270,left=0,top=0'); return false;">BBC Radio Scotland <span class="gvl3-icon gvl3-icon-boxedlive"> Live</span></a>
+
+		</h3>
+
+			</li>
+						</ul>
+	</div>
+<script type="text/javascript">$render("av-live-streams","av-live-streams");</script>
+
+</div>
+<script type="text/javascript">$render("container-av-best","av-best");</script> 
+	
+<div class="bbccom_advert_placeholder">
+	<script type="text/javascript">$render("advert","advert-mpu-low");</script>
+</div>
+<script type="text/javascript">$render("advert-post-script-load");</script>
+
+</div>
+<script type="text/javascript">$render("container-promo-best","promo-best");</script> 
+	
+<div id="features-and-analysis" class="container-features-and-analysis">
+ 		<h2 class="features-header">Features &amp; Analysis</h2>
+		
+ <ul>
+  	
+
+
+		
+	
+						
+			<!-- Non specific version -->
+			
+			
+							
+									
+												
+		<li class="first-child large-image">
+
+			
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h3 class=" feature-header">
+	<a class="story" rel="published-1396258295054" href="http://www.bbc.co.uk/news/uk-scotland-highlands-islands-26817526"><img src="BBC_News_Scotland_files/_73920849_markmedcalf.jpg" alt="Otter">Natural selection</a>
+
+		</h3>
+
+			
+							<p>The winning entries from the 2013 Scottish Nature Photography Awards 	
+				  <span id="dna-comment-count___CPS__26817526" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+			
+					</li>
+	
+	 
+	
+	
+
+
+  	
+
+
+		
+	
+						
+			<!-- Non specific version -->
+			
+			
+							
+		<li class="medium-image">
+
+			
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h3 class=" feature-header">
+	<a class="story" rel="published-1396225120997" href="http://www.bbc.co.uk/news/uk-scotland-tayside-central-26749122"><img src="BBC_News_Scotland_files/_73832235_16_blue00035.jpg" alt="Dundee waterfront image">Museum with a mission</a>
+
+		</h3>
+
+			
+							<p>V&amp;A Dundee aims to change thinking about design  	
+				  <span id="dna-comment-count___CPS__26749122" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+			
+							<hr>
+					</li>
+			
+							
+		<li class="medium-image">
+
+			
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h3 class=" feature-header">
+	<a class="story" rel="published-1396259119589" href="http://www.bbc.co.uk/news/uk-scotland-scotland-politics-26787241"><img src="BBC_News_Scotland_files/_73921954_mcleishhands_pa.jpg" alt="Henry McLeish, former Labour First Minister">Got a question?</a>
+
+		</h3>
+
+			
+							<p>Former FM Henry McLeish in the referendum webcast hot-seat 	
+				  <span id="dna-comment-count___CPS__26787241" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+			
+							<hr>
+					</li>
+			
+							
+		<li class="medium-image">
+
+			
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h3 class=" feature-header">
+	<a class="story" rel="published-1396223156644" href="http://www.bbc.co.uk/news/magazine-26730067"><img src="BBC_News_Scotland_files/_73929252_thekey-page5final.jpg" alt="A close up of her face, some sort of realisation dawns upon her. She stares open-mouthed.">The Key</a>
+
+		</h3>
+
+			
+							<p>A novel in graphic art form on the theme of freedom  	
+				  <span id="dna-comment-count___CPS__26730067" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+			
+							<hr>
+					</li>
+			
+							
+		<li class="medium-image">
+
+			
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h3 class=" feature-header">
+	<a class="story" rel="published-1396137699713" href="http://www.bbc.co.uk/news/uk-scotland-highlands-islands-26764969"><img src="BBC_News_Scotland_files/_73874302_postermontagefirst.jpg" alt="Belladrum poster illustrations">Art attack </a>
+
+		</h3>
+
+			
+							<p>How the idea for Belladrum's 50ft woman grew 	
+				  <span id="dna-comment-count___CPS__26764969" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+			
+							<hr>
+					</li>
+			
+							
+		<li class="medium-image">
+
+			
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h3 class=" feature-header">
+	<a class="story" rel="published-1396007990125" href="http://www.bbc.co.uk/news/uk-scotland-26785779"><img src="BBC_News_Scotland_files/_73906942_muckspreadingtorrofmoonzie.jpg" alt="Tractor spreading muck">Your pictures</a>
+
+		</h3>
+
+			
+							<p>A selection of your pictures taken across Scotland 	
+				  <span id="dna-comment-count___CPS__26785779" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+			
+							<hr>
+					</li>
+			
+							
+		<li class="medium-image">
+
+			
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h3 class=" feature-header">
+	<a class="story" rel="published-1393234575651" href="http://www.bbc.co.uk/news/uk-scotland-26322003"><img src="BBC_News_Scotland_files/_73918217_newspapers003.jpg" alt="Scotland's newspapers">Scottish papers</a>
+
+		</h3>
+
+			
+							<p>Newspaper review: Scotland's front pages 	
+				  <span id="dna-comment-count___CPS__26322003" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+			
+							<hr>
+					</li>
+			
+							
+		<li class="medium-image">
+
+			
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h3 class=" feature-header">
+	<a class="story" rel="published-1389203494700" href="http://www.bbc.co.uk/news/uk-scotland-scotland-politics-25657131"><img src="BBC_News_Scotland_files/_72161086_flags_seven.jpg" alt="Saltire and union flag">Join in</a>
+
+		</h3>
+
+			
+							<p>Apply to take part in a TV referendum debate 	
+				  <span id="dna-comment-count___CPS__25657131" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+			
+							<hr>
+					</li>
+			
+							
+		<li class="medium-image">
+
+			
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h3 class=" feature-header">
+	<a class="story" rel="published-1380190779983" href="https://twitter.com/BBCScotlandNews"><img src="BBC_News_Scotland_files/_70264710_tweetpromotoo.jpg" alt="Twitter">See our tweets</a>
+
+		</h3>
+
+			
+							<p>Follow the latest BBC Scotland News updates on Twitter 	
+				  <span id="dna-comment-count___CPS__24282939" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+			
+							<hr>
+					</li>
+	
+	 
+	
+	
+
+
+  	
+
+
+		
+	
+						
+			<!-- Non specific version -->
+			
+			
+							
+		<li class="no-image">
+
+			
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h3 class=" feature-header">
+	<a class="story" rel="published-1317896946303" href="http://www.bbc.co.uk/news/uk-scotland-scotland-politics-15190428">Take part</a>
+
+		</h3>
+
+			
+							<p>Join Brian Taylor's Big Debate audience  	
+				  <span id="dna-comment-count___CPS__15190428" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+			
+					</li>
+			
+							
+		<li class="no-image">
+
+			
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h3 class=" feature-header">
+	<a class="story" rel="published-1284383118762" href="http://www.bbc.co.uk/news/uk-scotland-11287381">Send us your pictures</a>
+
+		</h3>
+
+			
+							<p>How to send us your images from across Scotland  	
+				  <span id="dna-comment-count___CPS__11287381" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+			
+					</li>
+			
+							
+		<li class="no-image">
+
+			
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h3 class=" feature-header">
+	<a class="story" rel="published-1327399992043" href="http://www.bbc.co.uk/news/16630456">Scotland's future</a>
+
+		</h3>
+
+			
+							<p>Latest news, background and analysis on the 2014 referendum  	
+				  <span id="dna-comment-count___CPS__16698008" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+			
+					</li>
+			
+							
+		<li class="no-image">
+
+			
+
+
+
+
+	
+
+
+	
+
+
+
+
+<h3 class=" feature-header">
+	<a class="story" rel="published-1394451701516" href="https://www.facebook.com/bbcscotlandnews">We're on Facebook</a>
+
+		</h3>
+
+			
+							<p>Join us to get the highlights from BBC Scotland news 	
+				  <span id="dna-comment-count___CPS__26516189" class="gvl3-icon gvl3-icon-comment comment-count"></span></p>
+			
+					</li>
+	
+	 
+	
+	
+
+
+   </ul>
+</div>
+<script type="text/javascript">$render("container-features-and-analysis","features-and-analysis");</script> 
+
+	<div id="special-event-promotion-best-promo-module-hyper" class="include-only special-event-promotion-best">
+    	
+
+
+
+
+  <!-- Empty hyperpuff -->
+
+</div>
+<script type="text/javascript">$render("special-event-promotion-best-promo-module-hyper","special-event-promotion-best-promo-module-hyper");</script> 
+	<div id="special-event-promotion-best-1-include" class="include-only special-event-promotion-best">
+    	
+
+
+
+
+		     <div class="hyperpuff">
+	       	         <div id="promotional-content" class="hyper-promotional-content">
+	
+			<h2>Elsewhere on the BBC</h2>
+	
+	<ul>
+							
+						
+															
+										<li class="medium-image first-child">
+				
+
+
+
+
+	
+
+
+		
+
+
+
+
+<h3>
+	<a class="story" rel="published-1382701763924" href="http://www.bbc.co.uk/news/world-24733934"><img src="BBC_News_Scotland_files/_70711014_70706025.jpg" alt="Queen's Baton Relay">Baton relay</a>
+
+		</h3>
+
+									<p>70 nations and territories, 288 days - Mark Beaumont travels the Commonwealth </p>
+							</li>
+			</ul>
+	
+	<div class="bbccom_advert_placeholder">
+	      <script type="text/javascript">$render("advert","advert-sponsor-module","hyper-promotional-content","baton-relay");</script>
+	</div>
+	<script type="text/javascript">$render("advert-post-script-load");</script>
+ 
+</div>
+<script type="text/javascript">$render("hyper-promotional-content","promotional-content");</script>
+
+
+	       	     </div>
+	
+</div>
+<script type="text/javascript">$render("special-event-promotion-best-1-include","special-event-promotion-best-1-include");</script> 
+	
+<div id="most-popular-promotion" class="container-most-popular-promotion">
+	
+<div class="bbccom_advert_placeholder">
+	<script type="text/javascript">$render("advert","advert-partner-button");</script>
+</div>
+<script type="text/javascript">$render("advert-post-script-load");</script>
+
+	
+<div id="most-popular-category" class="livestats most-popular-category">
+
+			<h2 class="livestats-header">Most Popular</h2>
+		<h3 class="tab open">From Scotland in the last week</h3>
+	<div id="livestats-week" class="panel">
+  		<ol>
+      		<li class="ol">
+  <a class="story" href="http://www.bbc.co.uk/news/uk-scotland-26807255">
+    <span class="livestats-icon livestats-sunday">Sunday: </span>Scottish Yes vote 'not impossible'</a>
+</li><li class="ol">
+  <a class="story" href="http://www.bbc.co.uk/news/uk-scotland-glasgow-west-26787005">
+    <span class="livestats-icon livestats-saturday">Saturday: </span>Clutha victims remembered at service</a>
+</li><li class="ol">
+  <a class="story" href="http://www.bbc.co.uk/news/uk-scotland-north-east-orkney-shetland-26780189">
+    <span class="livestats-icon livestats-friday">Friday: </span>'Dambusters' squadron is disbanded</a>
+</li><li class="ol">
+  <a class="story" href="http://www.bbc.co.uk/news/uk-scotland-south-scotland-26756691">
+    <span class="livestats-icon livestats-thursday">Thursday: </span>'Asymmetric' school week approved</a>
+</li><li class="ol">
+  <a class="story" href="http://www.bbc.co.uk/news/uk-scotland-north-east-orkney-shetland-26731192">
+    <span class="livestats-icon livestats-wednesday">Wednesday: </span>Man wins 16-year laptop wrangle</a>
+</li>
+  		</ol>
+  	</div>
+	
+	<div class="bbccom_advert_placeholder">
+		<script type="text/javascript">$render("advert","advert-sponsor-module","most-popular-category","most-popular");</script>
+	</div>
+	<script type="text/javascript">$render("advert-post-script-load");</script>
+	
+    
+</div>
+
+<script type="text/javascript">$render("most-popular-category","most-popular-category");</script>
+</div>
+<script type="text/javascript">$render("container-most-popular-promotion","most-popular-promotion");</script> 
+	<div id="programmes-promotion" class="include-only programmes-promotion">
+    	
+
+
+
+
+		     <div class="hyperpuff">
+	       	             		  		    	
+    		    		    				  	    	  		  
+						  
+
+<div id="container-programme-promotion" class="container-programme-promotion">
+			<h2 class="programmes-header">Programmes</h2>
+		
+	
+		<a class="iplayer-branding" href="http://www.bbc.co.uk/iplayer/">BBC iPlayer</a>
+	
+
+								<ul class="programmes-standard">
+	
+				
+				
+	<li class="medium-image first-item">
+		
+
+
+
+
+		
+
+
+		
+
+
+
+
+<h3 class=" programme-header">
+	<a class="story" rel="published-1279103053874" href="http://www.bbc.co.uk/programmes/b006mj3s"><img src="BBC_News_Scotland_files/_48355416_b006mj3s_178_100.jpg" alt="Reporting Scotland">Reporting Scotland<span class="gvl3-icon-wrapper"><span class="gvl3-icon gvl3-icon-invert-watch"> Watch</span></span></a>
+
+		</h3>
+
+		<p>The latest news and weather from around Scotland.</p>
+		<hr>
+	</li>														
+</ul>
+		
+					<div id="data-feed-best" class="include-only data-feed-best">
+    	<ul><li class="medium-image"><h4 class="programme-header"><a class="story" href="http://www.bbc.co.uk/iplayer/episode/b03yr40c/Good_Morning_Scotland_31_03_2014/"><img alt="Good Morning Scotland: 31/03/2014" src="BBC_News_Scotland_files/b03yr40c_150_84.jpg">Good Morning Scotland<span class="gvl3-icon-wrapper"><span class="gvl3-icon gvl3-icon-invert-listen"> Listen</span></span></a></h4><p>The nation's morning news programme with Gary Robertson, Hayley Millar and Jim Naughtie.</p><hr></li><li class="medium-image"><h4 class="programme-header"><a class="story" href="http://www.bbc.co.uk/iplayer/episode/b03zjbg2/Newsnight_Scotland_27_03_2014/"><img alt="Newsnight Scotland: 27/03/2014" src="BBC_News_Scotland_files/b03zjbg2_150_84.jpg">Newsnight Scotland<span class="gvl3-icon-wrapper"><span class="gvl3-icon gvl3-icon-invert-watch"> Watch</span></span></a></h4><p>Coverage of the day's national and international news stories, with Gordon Brewer.</p><hr></li></ul>
+</div>
+<script type="text/javascript">$render("data-feed-best","data-feed-best");</script> 		
+	</div>
+<script type="text/javascript">$render("container-programmes-promotion","container-programme-promotion");</script>
+	
+	       	     </div>
+	
+</div>
+<script type="text/javascript">$render("programmes-promotion","programmes-promotion");</script> 
+	
+<div class="bbccom_advert_placeholder">
+	<script type="text/javascript">$render("advert","advert-mpu-bottom");</script>
+</div>
+<script type="text/javascript">$render("advert-post-script-load");</script>
+
+	
+<div class="bbccom_advert_placeholder">
+	<script type="text/javascript">$render("advert","advert-google-adsense");</script>
+</div>
+<script type="text/javascript">$render("advert-post-script-load");</script>
+
+</div>
+<script type="text/javascript">$render("container-best","best");</script> 
+
+	<!-- END #MAIN-CONTENT & CPS_ASSET_TYPE CLASS: index -->
+	</div>
+<!-- END CPS_AUDIENCE CLASS: domestic -->
+	
+</div> 
+<div id="related-services" class="footer">
+   <div id="news-services">
+      <h2>Services</h2>  
+	   <ul>
+         <li id="service-mobile" class="first-child"><a href="http://www.bbc.co.uk/news/10628994"><span class="gvl3-mobile-icon-large services-icon">&nbsp;</span>Mobile</a></li>
+         <li id="service-feeds"><a href="http://www.bbc.co.uk/news/help-17655000"><span class="gvl3-connected-tv-icon-large services-icon">&nbsp;</span>Connected TV</a></li>
+         <li id="service-podcast"><a href="http://www.bbc.co.uk/news/10628494"><span class="gvl3-feeds-icon-large services-icon">&nbsp;</span>News feeds</a></li>
+         <li id="service-alerts"><a href="http://www.bbc.co.uk/news/10628323"><span class="gvl3-alerts-icon-large services-icon">&nbsp;</span>Alerts</a></li>
+         <li id="service-email-news"><a href="http://www.bbc.co.uk/news/help/16617948"><span class="gvl3-email-icon-large services-icon">&nbsp;</span>E-mail news</a></li>
+      </ul>	  
+   </div>
+   <div id="news-related-sites">
+      <h2><a href="http://www.bbc.co.uk/news/19888761">About BBC News</a></h2>
+      <ul>
+         <li class="column-1"><a href="http://www.bbc.co.uk/news/blogs/the_editors/">Editors' blog</a></li>
+         <li class="column-1"><a href="http://www.bbc.co.uk/journalism/">BBC College of Journalism</a></li>
+         <li class="column-1"><a href="http://www.bbc.co.uk/news/10621655">News sources</a></li>
+         <li class="column-1"><a href="http://www.bbc.co.uk/editorialguidelines/">Editorial Guidelines</a></li>
+      </ul>
+   </div>
+</div>
+</div><!-- close scotland -->
+
+
+
+	
+	
+
+   </div>   <!--[if IE 6]> <div id="blq-ie6-upgrade"> <p> <span>You're using the Internet Explorer 6 browser to view the BBC website. Our site will work much better if you change to a more modern browser. It's free, quick and easy.</span> <a href="http://www.browserchoice.eu/">Find out more <span>about upgrading your browser</span> here&hellip;</a> </p> </div> <![endif]-->  <div role="contentinfo" id="blq-foot" xml:lang="en-GB" class="blq-rst blq-clearfix blq-foot-transparent blq-foot-text-dark"> <div id="blq-footlinks"> <h2 class="blq-hide">BBC links</h2>       <ul>                    <li role="presentation" class="blq-footlinks-row"> <ul role="presentation" class="blq-footlinks-row-list"> <li><a href="http://www.bbc.co.uk/news/mobile/" id="blq-footer-mobile">Mobile site</a></li><li><a href="http://www.bbc.co.uk/terms/">Terms of Use</a></li><li><a href="http://www.bbc.co.uk/aboutthebbc/">About the BBC</a></li> </ul> </li>                <li role="presentation" class="blq-footlinks-row"> <ul role="presentation" class="blq-footlinks-row-list"> <li><a href="http://www.bbc.co.uk/privacy/">Privacy</a></li><li><a href="http://www.bbc.co.uk/accessibility/">Accessibility Help</a></li> </ul> </li>                <li role="presentation" class="blq-footlinks-row"> <ul role="presentation" class="blq-footlinks-row-list"> <li><a href="http://www.bbc.co.uk/privacy/bbc-cookies-policy.shtml">Cookies</a></li><li><a href="http://www.bbc.co.uk/news/20039682">Contact the BBC</a></li> </ul> </li>           <li role="presentation" class="blq-footlinks-row"> <ul role="presentation" class="blq-footlinks-row-list"> <li><a href="http://www.bbc.co.uk/guidance/">Parental Guidance</a></li> </ul> </li>             </ul> <script type="text/javascript">/*<![CDATA[*/ (function() { var mLink = document.getElementById('blq-footer-mobile'), stick = function() { var d = new Date (); d.setYear(d.getFullYear() + 1); d = d.toUTCString(); window.bbccookies.set('ckps_d=m;domain=.bbc.co.uk;path=/;expires=' + d ); window.bbccookies.set('ckps_d=m;domain=.bbc.com;path=/;expires=' + d ); }; if (mLink) {  if (mLink.addEventListener) { mLink.addEventListener('click', stick, false); } else if (mLink.attachEvent) { mLink.attachEvent('onclick', stick); } } })(); /*]]>*/</script>  </div>  <div id="blq-foot-blocks" class="blq-footer-image-dark"><img src="BBC_News_Scotland_files/dark.png" alt="BBC" height="24" width="84"></div>  <p id="blq-disclaim"><span id="blq-copy">BBC © 2014</span> <a href="http://www.bbc.co.uk/help/web/links/">The BBC is not responsible for the content of external sites. Read more.</a></p> <div id="blq-obit"><p><strong>This
+ page is best viewed in an up-to-date web browser with style sheets 
+(CSS) enabled. While you will be able to view the content of this page 
+in your current browser, you will not be able to get the full visual 
+experience. Please consider upgrading your browser software or enabling 
+style sheets (CSS) if you are able to do so.</strong></p></div> </div> </div>  </div> </div>  <script type="text/javascript"> if (typeof require !== 'undefined') { require(['istats-1'], function(istats){ istats.track('external', { region: document.getElementById('blq-main') }); istats.track('download', { region: document.getElementById('blq-main') }); }); } </script>  <script type="text/html" id="blq-panel-template-promo"><![CDATA[ <div id="blq-panel-promo" class="blq-masthead-container"></div> ]]></script> <script type="text/html" id="blq-panel-template-more"><![CDATA[ <div id="blq-panel-more" class="blq-masthead-container  blq-clearfix" xml:lang="en-GB" dir="ltr"> <div class="blq-panel-container panel-paneltype-more"> <div class="panel-header"> <h2> <a href="http://www.bbc.co.uk/a-z/">  More&hellip;  </a> </h2>  <a href="http://www.bbc.co.uk/a-z/" class="panel-header-links panel-header-link">Full A-Z<span class="blq-hide"> of BBC sites</span></a>  </div> <div class="panel-component panel-links">       <ul>   <li> <a href="http://www.bbc.co.uk/cbbc/"  >CBBC</a> </li>    <li> <a href="http://www.bbc.co.uk/cbeebies/"  >CBeebies</a> </li>    <li> <a href="http://www.bbc.co.uk/comedy/"  >Comedy</a> </li>   </ul>  <ul>   <li> <a href="http://www.bbc.co.uk/food/"  >Food</a> </li>    <li> <a href="http://www.bbc.co.uk/history/"  >History</a> </li>    <li> <a href="http://www.bbc.co.uk/learning/"  >Learning</a> </li>   </ul>  <ul>   <li> <a href="http://www.bbc.co.uk/music/"  >Music</a> </li>    <li> <a href="http://www.bbc.co.uk/science/"  >Science</a> </li>    <li> <a href="http://www.bbc.co.uk/nature/"  >Nature</a> </li>   </ul>  <ul>   <li> <a href="http://www.bbc.co.uk/local/"  >Local</a> </li>    <li> <a href="http://www.bbc.co.uk/travelnews/"  >Travel News</a> </li>   </ul>   </div> </div> ]]></script>             <script type="text/javascript"> pulse.init( 'news-scotland', false ); </script> 
+	
+
+<!-- shared/foot -->
+<script type="text/javascript">
+	bbc.fmtj.common.removeNoScript({});
+	bbc.fmtj.common.tabs.createTabs({});
+</script>
+<!-- hi/news/foot.inc -->
+
+<!-- Chartbeat Web Analytics code - start -->
+<script type="text/javascript">
+var _sf_async_config={};
+/** CONFIGURATION START **/
+_sf_async_config.uid = 50924; /** Chartbeat BBC id **/
+_sf_async_config.domain = "bbc.co.uk";/** BBC domain being tracked **/
+_sf_async_config.sections = "scotland";
+_sf_async_config.region = "domestic";
+
+  
+
+/** CONFIGURATION END **/
+(function(){
+  function loadChartbeat() {
+    window._sf_endpt=(new Date()).getTime();
+    var e = document.createElement("script");
+    e.setAttribute("language", "javascript");
+    e.setAttribute("type", "text/javascript");
+    e.setAttribute('src', '/inc/specials/cream/hi/news/chartbeat/chartbeat.js');
+    document.body.appendChild(e);
+  }
+  var oldonload = window.onload;
+  window.onload = (typeof window.onload != "function") ?
+     loadChartbeat : function() { oldonload(); loadChartbeat(); };
+})();
+</script>
+<!-- Chartbeat Web Analytics code - end -->
+<!-- shared/foot_index -->
+<!-- #CREAM hi news domestic foot.inc -->
+
+ 
+
+              
+  
+
+
+	
+    		
+		
+	
+    	
+   
+
+<!-- CPS COMMENT STATUS: false -->
+
+
+<script type="text/javascript" src="BBC_News_Scotland_files/a"></script>
+
+
+
+
+<div class="glow177-cssTest" style="height:0;position:absolute;visibility:hidden;top:-20px;display:block"></div><script src="BBC_News_Scotland_files/chartbeat.js" type="text/javascript" language="javascript"></script></body></html>


### PR DESCRIPTION
*Context*
This PR is a WIP.
The unit test attempt sot perform a simple document extraction using the BBC Scotland HTML as input.

*How to debug*
One can inspect the `TriXExtractor` issues by setting a breakpoint at [org/apache/any23/extractor/SingleDocumentExtraction.java#L543](https://github.com/apache/any23/blob/master/core/src/main/java/org/apache/any23/extractor/SingleDocumentExtraction.java#L543). You can then evaluate the following expression

```
extractionResult.getIssues().toArray()[1]
```

This indicates the following

```
FATAL: 	'org.eclipse.rdf4j.rio.RDFParseException: The attribute name must be specified in the attribute-list declaration for element "charset". [line 181, column 45]
	at org.eclipse.rdf4j.rio.helpers.RDFParserHelper.reportFatalError(RDFParserHelper.java:333)
	at org.eclipse.rdf4j.rio.helpers.AbstractRDFParser.reportFatalError(AbstractRDFParser.java:724)
	at org.eclipse.rdf4j.rio.trix.TriXParser.reportFatalError(TriXParser.java:253)
	at org.eclipse.rdf4j.rio.trix.TriXParser.fatalError(TriXParser.java:419)
	at org.apache.xerces.util.ErrorHandlerWrapper.fatalError(Unknown Source)
	at org.apache.xerces.impl.XMLErrorReporter.reportError(Unknown Source)
	at org.apache.xerces.impl.XMLErrorReporter.reportError(Unknown Source)
	at org.apache.xerces.impl.XMLErrorReporter.reportError(Unknown Source)
	at org.apache.xerces.impl.XMLScanner.reportFatalError(Unknown Source)
	at org.apache.xerces.impl.XMLDTDScannerImpl.scanAttlistDecl(Unknown Source)
	at org.apache.xerces.impl.XMLDTDScannerImpl.scanDecls(Unknown Source)
	at org.apa...' 	(-1,-1)
```