### PR TITLE
ANY23-523 Bump owlapi.version from 5.1.13 to 5.1.19 and RDF4J to 3.7.3 

### DIFF
--- a/api/src/main/java/org/apache/any23/vocab/Vocabulary.java
+++ b/api/src/main/java/org/apache/any23/vocab/Vocabulary.java
@@ -86,7 +86,7 @@ public abstract class Vocabulary {
      * @return the namespace associated to this vocabulary.
      */
     public IRI getNamespace() {
-        return namespace;
+        return this.namespace;
     }
 
     /**
@@ -98,7 +98,7 @@ public abstract class Vocabulary {
      * @return the IRI associated to such resource.
      */
     public IRI getClass(String name) {
-        IRI res = classes.get(name);
+        IRI res = this.classes.get(name);
         if (null == res) {
             throw new IllegalArgumentException("Unknown resource name '" + name + "'");
         }
@@ -114,7 +114,7 @@ public abstract class Vocabulary {
      * @return the IRI associated to such property.
      */
     public IRI getProperty(String name) {
-        IRI prop = properties.get(name);
+        IRI prop = this.properties.get(name);
         if (null == prop) {
             throw new IllegalArgumentException("Unknown property name '" + name + "'");
         }
@@ -132,7 +132,7 @@ public abstract class Vocabulary {
      * @return the IRI associated to such property.
      */
     public IRI getProperty(String name, IRI defaultValue) {
-        IRI prop = properties.get(name);
+        IRI prop = this.properties.get(name);
         if (null == prop) {
             return defaultValue;
         }
@@ -162,10 +162,10 @@ public abstract class Vocabulary {
      * @return the list of all defined classes.
      */
     public IRI[] getClasses() {
-        if (classes == null) {
+        if (this.classes == null) {
             return new IRI[0];
         }
-        final Collection<IRI> iris = classes.values();
+        final Collection<IRI> iris = this.classes.values();
         return iris.toArray(new IRI[iris.size()]);
     }
 
@@ -173,10 +173,10 @@ public abstract class Vocabulary {
      * @return the list of all defined properties.
      */
     public IRI[] getProperties() {
-        if (properties == null) {
+        if (this.properties == null) {
             return new IRI[0];
         }
-        final Collection<IRI> iris = properties.values();
+        final Collection<IRI> iris = this.properties.values();
         return iris.toArray(new IRI[iris.size()]);
     }
 
@@ -187,7 +187,7 @@ public abstract class Vocabulary {
      */
     public Map<IRI, String> getComments() {
         fillResourceToCommentMap();
-        return Collections.unmodifiableMap(resourceToCommentMap);
+        return Collections.unmodifiableMap(this.resourceToCommentMap);
     }
 
     /**
@@ -200,7 +200,7 @@ public abstract class Vocabulary {
      */
     public String getCommentFor(IRI resource) {
         fillResourceToCommentMap();
-        return resourceToCommentMap.get(resource);
+        return this.resourceToCommentMap.get(resource);
     }
 
     /**
@@ -211,7 +211,7 @@ public abstract class Vocabulary {
      * 
      * @return the IRI instance.
      */
-    protected IRI createIRI(String iriStr) {
+    protected static IRI createIRI(String iriStr) {
         return SimpleValueFactory.getInstance().createIRI(iriStr);
     }
 
@@ -227,10 +227,10 @@ public abstract class Vocabulary {
      */
     protected IRI createClass(String namespace, String resource) {
         IRI res = createIRI(namespace, resource);
-        if (classes == null) {
-            classes = new HashMap<>(10);
+        if (this.classes == null) {
+            this.classes = new HashMap<>(10);
         }
-        classes.put(resource, res);
+        this.classes.put(resource, res);
         return res;
     }
 
@@ -246,10 +246,10 @@ public abstract class Vocabulary {
      */
     protected IRI createProperty(String namespace, String property) {
         IRI res = createIRI(namespace, property);
-        if (properties == null) {
-            properties = new HashMap<>(10);
+        if (this.properties == null) {
+            this.properties = new HashMap<>(10);
         }
-        properties.put(property, res);
+        this.properties.put(property, res);
         return res;
     }
 
@@ -261,12 +261,12 @@ public abstract class Vocabulary {
      * 
      * @return
      */
-    private IRI createIRI(String namespace, String localName) {
+    private static IRI createIRI(String namespace, String localName) {
         return SimpleValueFactory.getInstance().createIRI(namespace, localName);
     }
 
     private void fillResourceToCommentMap() {
-        if (resourceToCommentMap != null)
+        if (this.resourceToCommentMap != null)
             return;
         final Map<IRI, String> newMap = new HashMap<>();
         for (Field field : this.getClass().getFields()) {
@@ -281,7 +281,7 @@ public abstract class Vocabulary {
                 throw new RuntimeException("Error while creating resource to comment map.", iae);
             }
         }
-        resourceToCommentMap = newMap;
+        this.resourceToCommentMap = newMap;
     }
 
 }

--- a/api/src/main/java/org/apache/any23/writer/TripleFormat.java
+++ b/api/src/main/java/org/apache/any23/writer/TripleFormat.java
@@ -63,11 +63,11 @@ public class TripleFormat {
 
         public boolean has(Capabilities other) {
             int oraw = other.raw;
-            return (raw & oraw) == oraw;
+            return (this.raw & oraw) == oraw;
         }
 
         private Capabilities withNamespaces() {
-            return new Capabilities(raw | WRITES_NAMESPACES);
+            return new Capabilities(this.raw | WRITES_NAMESPACES);
         }
 
         // TODO: add "supportsComments()"
@@ -163,7 +163,7 @@ public class TripleFormat {
     }
 
     public Optional<Charset> getCharset() {
-        return Optional.ofNullable(charset);
+        return Optional.ofNullable(this.charset);
     }
 
     static Capabilities capabilities(RDFFormat format) {
@@ -186,7 +186,7 @@ public class TripleFormat {
     }
 
     RDFFormat toRDFFormat() {
-        RDFFormat fmt = rdfFormat;
+        RDFFormat fmt = this.rdfFormat;
         if (fmt != null) {
             return fmt;
         }
@@ -194,41 +194,41 @@ public class TripleFormat {
         if (!capabilities.has(TRIPLES)) {
             throw new UnsupportedOperationException("This format does not print RDF triples");
         }
-        return rdfFormat = new RDFFormat(name, mimeTypes, charset, fileExtensions, standardIRI,
-                capabilities.has(TRIPLES_AND_NAMESPACES), capabilities.has(QUADS));
+        return this.rdfFormat = new RDFFormat(this.name, this.mimeTypes, this.charset, this.fileExtensions,
+                this.standardIRI, capabilities.has(TRIPLES_AND_NAMESPACES), capabilities.has(QUADS), false);
     }
 
     public Optional<IRI> getStandardIRI() {
-        return Optional.ofNullable(standardIRI);
+        return Optional.ofNullable(this.standardIRI);
     }
 
     public List<String> getMimeTypes() {
-        return mimeTypes;
+        return this.mimeTypes;
     }
 
     public String getMimeType() {
-        return mimeTypes.get(0);
+        return this.mimeTypes.get(0);
     }
 
     public List<String> getExtensions() {
-        return fileExtensions;
+        return this.fileExtensions;
     }
 
     public Optional<String> getExtension() {
-        return fileExtensions.isEmpty() ? Optional.empty() : Optional.of(fileExtensions.get(0));
+        return this.fileExtensions.isEmpty() ? Optional.empty() : Optional.of(this.fileExtensions.get(0));
     }
 
     public Capabilities getCapabilities() {
-        return capabilities;
+        return this.capabilities;
     }
 
     public String getDisplayName() {
-        return name;
+        return this.name;
     }
 
     public String toString() {
-        return name + mimeTypes.stream().collect(Collectors.joining(", ", " (mimeTypes=", "; "))
-                + fileExtensions.stream().collect(Collectors.joining(", ", "ext=", ")"));
+        return this.name + this.mimeTypes.stream().collect(Collectors.joining(", ", " (mimeTypes=", "; "))
+                + this.fileExtensions.stream().collect(Collectors.joining(", ", "ext=", ")"));
     }
 
 }

--- a/cli/src/test/java/org/apache/any23/cli/flows/PeopleExtractor.java
+++ b/cli/src/test/java/org/apache/any23/cli/flows/PeopleExtractor.java
@@ -33,7 +33,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +65,7 @@ public class PeopleExtractor extends CompositeTripleHandler {
         Model model = new TreeModel();
         model.add(s, RDF.TYPE, PERSON);
         model.add(s, FULL_NAME, vf.createLiteral(fullName));
-        model.add(s, HASH, vf.createLiteral(s.getLocalName(), XMLSchema.HEXBINARY));
+        model.add(s, HASH, vf.createLiteral(s.getLocalName(), XSD.HEXBINARY));
         return model;
     };
 
@@ -79,7 +79,7 @@ public class PeopleExtractor extends CompositeTripleHandler {
     public void receiveTriple(Resource s, IRI p, Value o, IRI g, ExtractionContext context)
             throws TripleHandlerException {
         if ("csv".equals(context.getExtractorName())) {
-            csvModel.add(s, p, o, vf.createIRI(context.getUniqueID()));
+            this.csvModel.add(s, p, o, vf.createIRI(context.getUniqueID()));
         } else {
             super.receiveTriple(s, p, o, g, context);
         }
@@ -87,17 +87,17 @@ public class PeopleExtractor extends CompositeTripleHandler {
 
     @Override
     public void closeContext(ExtractionContext context) throws TripleHandlerException {
-        Set<Resource> subjects = csvModel.filter(null, RDF.TYPE, csv.rowType).stream().map(Statement::getSubject)
+        Set<Resource> subjects = this.csvModel.filter(null, RDF.TYPE, csv.rowType).stream().map(Statement::getSubject)
                 .collect(Collectors.toSet());
 
-        log.debug("List of rows: {}", subjects);
+        this.log.debug("List of rows: {}", subjects);
 
         for (Resource rowId : subjects) {
-            String firstName = Models.objectLiteral(csvModel.filter(rowId, RAW_FIRST_NAME, null)).map(Literal::getLabel)
-                    .orElse("");
+            String firstName = Models.objectLiteral(this.csvModel.filter(rowId, RAW_FIRST_NAME, null))
+                    .map(Literal::getLabel).orElse("");
 
-            String lastName = Models.objectLiteral(csvModel.filter(rowId, RAW_LAST_NAME, null)).map(Literal::getLabel)
-                    .orElse("");
+            String lastName = Models.objectLiteral(this.csvModel.filter(rowId, RAW_LAST_NAME, null))
+                    .map(Literal::getLabel).orElse("");
 
             String fullName = firstName + " " + lastName;
 
@@ -106,7 +106,7 @@ public class PeopleExtractor extends CompositeTripleHandler {
             }
         }
 
-        csvModel.clear();
+        this.csvModel.clear();
 
         super.closeContext(context);
     }

--- a/core/src/main/java/org/apache/any23/extractor/calendar/BaseCalendarExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/calendar/BaseCalendarExtractor.java
@@ -53,7 +53,7 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -93,7 +93,7 @@ abstract class BaseCalendarExtractor implements Extractor.ContentExtractor {
             InputStream inputStream, ExtractionResult result) throws IOException, ExtractionException {
         result.writeNamespace(RDF.PREFIX, RDF.NAMESPACE);
         result.writeNamespace(ICAL.PREFIX, ICAL.NS);
-        result.writeNamespace(XMLSchema.PREFIX, XMLSchema.NAMESPACE);
+        result.writeNamespace(XSD.PREFIX, XSD.NAMESPACE);
 
         ScribeIndex index = new ScribeIndex();
         try (StreamReader reader = reader(inputStream)) {
@@ -216,35 +216,35 @@ abstract class BaseCalendarExtractor implements Extractor.ContentExtractor {
 
     private static IRI dataType(ICalDataType dataType, Boolean isFloating) {
         if (dataType == null || ICalDataType.TEXT.equals(dataType)) {
-            return XMLSchema.STRING;
+            return XSD.STRING;
         } else if (ICalDataType.BOOLEAN.equals(dataType)) {
-            return XMLSchema.BOOLEAN;
+            return XSD.BOOLEAN;
         } else if (ICalDataType.INTEGER.equals(dataType)) {
-            return XMLSchema.INTEGER;
+            return XSD.INTEGER;
         } else if (ICalDataType.FLOAT.equals(dataType)) {
-            return XMLSchema.FLOAT;
+            return XSD.FLOAT;
         } else if (ICalDataType.BINARY.equals(dataType)) {
-            return XMLSchema.BASE64BINARY;
+            return XSD.BASE64BINARY;
         } else if (ICalDataType.URI.equals(dataType) || ICalDataType.URL.equals(dataType)
                 || ICalDataType.CONTENT_ID.equals(dataType) || ICalDataType.CAL_ADDRESS.equals(dataType)) {
-            return XMLSchema.ANYURI;
+            return XSD.ANYURI;
         } else if (ICalDataType.DATE_TIME.equals(dataType)) {
             if (isFloating == null) {
                 return null;
             }
-            return isFloating ? vICAL.DATE_TIME : XMLSchema.DATETIME;
+            return isFloating ? vICAL.DATE_TIME : XSD.DATETIME;
         } else if (ICalDataType.DATE.equals(dataType)) {
-            return XMLSchema.DATE;
+            return XSD.DATE;
         } else if (ICalDataType.TIME.equals(dataType)) {
-            return XMLSchema.TIME;
+            return XSD.TIME;
         } else if (ICalDataType.DURATION.equals(dataType)) {
-            return XMLSchema.DURATION;
+            return XSD.DURATION;
         } else if (ICalDataType.PERIOD.equals(dataType)) {
             return vICAL.Value_PERIOD;
         } else if (ICalDataType.RECUR.equals(dataType)) {
             return vICAL.Value_RECUR;
         } else {
-            return XMLSchema.STRING;
+            return XSD.STRING;
         }
     }
 
@@ -255,7 +255,7 @@ abstract class BaseCalendarExtractor implements Extractor.ContentExtractor {
             return s;
         }
         try {
-            if (XMLSchema.DURATION.equals(dataType)) {
+            if (XSD.DURATION.equals(dataType)) {
                 Matcher m = durationWeeksPattern.matcher(s);
                 if (m.matches()) {
                     long days = Long.parseLong(m.group(2)) * 7;
@@ -265,7 +265,7 @@ abstract class BaseCalendarExtractor implements Extractor.ContentExtractor {
                 if (s.indexOf('/') == -1) {
                     throw new IllegalArgumentException();
                 }
-            } else if (zone != null && XMLSchema.DATETIME.equals(dataType)) {
+            } else if (zone != null && XSD.DATETIME.equals(dataType)) {
                 try {
                     DateTimeComponents dt = DateTimeComponents.parse(s);
                     if (!dt.isUtc()) {
@@ -320,13 +320,13 @@ abstract class BaseCalendarExtractor implements Extractor.ContentExtractor {
             } else {
                 String str = normalizeAndReportIfInvalid(val.toString(), dataType, zone, result);
 
-                if (XMLSchema.STRING.equals(dataType)) {
+                if (XSD.STRING.equals(dataType)) {
                     if (lang == null) {
                         v = f.createLiteral(str);
                     } else {
                         v = f.createLiteral(str, lang);
                     }
-                } else if (XMLSchema.ANYURI.equals(dataType)) {
+                } else if (XSD.ANYURI.equals(dataType)) {
                     try {
                         v = f.createIRI(str);
                     } catch (IllegalArgumentException e) {
@@ -335,12 +335,12 @@ abstract class BaseCalendarExtractor implements Extractor.ContentExtractor {
                 } else if (vICAL.Value_PERIOD.equals(dataType)) {
                     String[] strs = str.split("/");
                     if (strs.length == 2) {
-                        String firstPart = normalizeAndReportIfInvalid(strs[0], XMLSchema.DATETIME, zone, result);
+                        String firstPart = normalizeAndReportIfInvalid(strs[0], XSD.DATETIME, zone, result);
                         String secondPart = strs[1];
                         if (secondPart.indexOf('P') != -1) { // duration
-                            secondPart = normalizeAndReportIfInvalid(secondPart, XMLSchema.DURATION, zone, result);
+                            secondPart = normalizeAndReportIfInvalid(secondPart, XSD.DURATION, zone, result);
                         } else {
-                            secondPart = normalizeAndReportIfInvalid(secondPart, XMLSchema.DATETIME, zone, result);
+                            secondPart = normalizeAndReportIfInvalid(secondPart, XSD.DATETIME, zone, result);
                         }
                         str = firstPart + "/" + secondPart;
                     }
@@ -375,8 +375,7 @@ abstract class BaseCalendarExtractor implements Extractor.ContentExtractor {
             BNode bNode = f.createBNode();
             result.writeTriple(subject, predicate, bNode);
             for (Map.Entry<String, JsonValue> entry : object.entrySet()) {
-                writeValue(bNode, predicate(entry.getKey(), result), entry.getValue(), lang, XMLSchema.STRING, zone,
-                        result);
+                writeValue(bNode, predicate(entry.getKey(), result), entry.getValue(), lang, XSD.STRING, zone, result);
             }
             return true;
         }

--- a/core/src/main/java/org/apache/any23/extractor/csv/CSVExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/csv/CSVExtractor.java
@@ -34,7 +34,7 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
-import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -88,7 +88,7 @@ public class CSVExtractor implements Extractor.ContentExtractor {
         int index = 0;
         while (rows.hasNext()) {
             CSVRecord nextLine = rows.next();
-            IRI rowSubject = RDFUtils.iri(documentIRI.toString(), "row/" + index);
+            IRI rowSubject = RDFUtils.iri(documentIRI.stringValue(), "row/" + index);
             // add a row type
             out.writeTriple(rowSubject, RDF.TYPE, csv.rowType);
             // for each row produce its statements
@@ -153,7 +153,7 @@ public class CSVExtractor implements Extractor.ContentExtractor {
                 out.writeTriple(singleHeader, RDFS.LABEL, SimpleValueFactory.getInstance().createLiteral(headerString));
             }
             out.writeTriple(singleHeader, csv.columnPosition,
-                    SimpleValueFactory.getInstance().createLiteral(String.valueOf(index), XMLSchema.INTEGER));
+                    SimpleValueFactory.getInstance().createLiteral(String.valueOf(index), XSD.INTEGER));
             index++;
         }
     }
@@ -232,11 +232,11 @@ public class CSVExtractor implements Extractor.ContentExtractor {
         if (RDFUtils.isAbsoluteIRI(newCell)) {
             object = SimpleValueFactory.getInstance().createIRI(newCell);
         } else {
-            IRI datatype = XMLSchema.STRING;
+            IRI datatype = XSD.STRING;
             if (isInteger(newCell)) {
-                datatype = XMLSchema.INTEGER;
+                datatype = XSD.INTEGER;
             } else if (isFloat(newCell)) {
-                datatype = XMLSchema.FLOAT;
+                datatype = XSD.FLOAT;
             }
             object = SimpleValueFactory.getInstance().createLiteral(newCell, datatype);
         }
@@ -255,9 +255,9 @@ public class CSVExtractor implements Extractor.ContentExtractor {
     private void addTableMetadataStatements(IRI documentIRI, ExtractionResult out, int numberOfRows,
             int numberOfColumns) {
         out.writeTriple(documentIRI, csv.numberOfRows,
-                SimpleValueFactory.getInstance().createLiteral(String.valueOf(numberOfRows), XMLSchema.INTEGER));
+                SimpleValueFactory.getInstance().createLiteral(String.valueOf(numberOfRows), XSD.INTEGER));
         out.writeTriple(documentIRI, csv.numberOfColumns,
-                SimpleValueFactory.getInstance().createLiteral(String.valueOf(numberOfColumns), XMLSchema.INTEGER));
+                SimpleValueFactory.getInstance().createLiteral(String.valueOf(numberOfColumns), XSD.INTEGER));
     }
 
     /**

--- a/core/src/main/java/org/apache/any23/extractor/microdata/ItemPropValue.java
+++ b/core/src/main/java/org/apache/any23/extractor/microdata/ItemPropValue.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 
 import org.apache.any23.util.StringUtils;
 import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
 
 /**
  * Describes a possible value for a <b>Microdata item property</b>.
@@ -108,7 +108,7 @@ public class ItemPropValue {
         Object content;
 
         // for backwards compatibility:
-        if (XMLSchema.DATE.equals(literal.getDatatype()) || XMLSchema.DATETIME.equals(literal.getDatatype())) {
+        if (XSD.DATE.equals(literal.getDatatype()) || XSD.DATETIME.equals(literal.getDatatype())) {
             try {
                 content = parseDateTime(literal.getLabel());
                 type = Type.Date;

--- a/core/src/main/java/org/apache/any23/extractor/microdata/MicrodataParser.java
+++ b/core/src/main/java/org/apache/any23/extractor/microdata/MicrodataParser.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
-import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.jsoup.parser.Tag;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -351,9 +351,9 @@ public class MicrodataParser {
             String value = value(node, "value");
             Literal l;
             if (XMLDatatypeUtil.isValidInteger(value)) {
-                l = RDFUtils.literal(value, XMLSchema.INTEGER);
+                l = RDFUtils.literal(value, XSD.INTEGER);
             } else if (XMLDatatypeUtil.isValidDouble(value)) {
-                l = RDFUtils.literal(value, XMLSchema.DOUBLE);
+                l = RDFUtils.literal(value, XSD.DOUBLE);
             } else {
                 l = RDFUtils.literal(value);
             }
@@ -363,17 +363,17 @@ public class MicrodataParser {
             String dateTimeStr = value(node, "datetime");
             Literal l;
             if (XMLDatatypeUtil.isValidDate(dateTimeStr)) {
-                l = RDFUtils.literal(dateTimeStr, XMLSchema.DATE);
+                l = RDFUtils.literal(dateTimeStr, XSD.DATE);
             } else if (XMLDatatypeUtil.isValidTime(dateTimeStr)) {
-                l = RDFUtils.literal(dateTimeStr, XMLSchema.TIME);
+                l = RDFUtils.literal(dateTimeStr, XSD.TIME);
             } else if (XMLDatatypeUtil.isValidDateTime(dateTimeStr)) {
-                l = RDFUtils.literal(dateTimeStr, XMLSchema.DATETIME);
+                l = RDFUtils.literal(dateTimeStr, XSD.DATETIME);
             } else if (XMLDatatypeUtil.isValidGYearMonth(dateTimeStr)) {
-                l = RDFUtils.literal(dateTimeStr, XMLSchema.GYEARMONTH);
+                l = RDFUtils.literal(dateTimeStr, XSD.GYEARMONTH);
             } else if (XMLDatatypeUtil.isValidGYear(dateTimeStr)) {
-                l = RDFUtils.literal(dateTimeStr, XMLSchema.GYEAR);
+                l = RDFUtils.literal(dateTimeStr, XSD.GYEAR);
             } else if (XMLDatatypeUtil.isValidDuration(dateTimeStr)) {
-                l = RDFUtils.literal(dateTimeStr, XMLSchema.DURATION);
+                l = RDFUtils.literal(dateTimeStr, XSD.DURATION);
             } else {
                 l = RDFUtils.literal(dateTimeStr, getLanguage(node));
             }

--- a/core/src/main/java/org/apache/any23/extractor/rdf/BaseRDFExtractor.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/BaseRDFExtractor.java
@@ -90,7 +90,6 @@ public abstract class BaseRDFExtractor implements Extractor.ContentExtractor {
     }
 
     // keep package-access to avoid backwards compatibility woes if protected (may move around later)
-    @SuppressWarnings("Duplicates")
     static String toString(Throwable th) {
         StringWriter writer = new StringWriter();
         try (PrintWriter pw = new PrintWriter(writer)) {

--- a/core/src/main/java/org/apache/any23/extractor/rdf/RDFXMLExtractorFactory.java
+++ b/core/src/main/java/org/apache/any23/extractor/rdf/RDFXMLExtractorFactory.java
@@ -39,10 +39,8 @@ public class RDFXMLExtractorFactory extends SimpleExtractorFactory<RDFXMLExtract
 
     public RDFXMLExtractorFactory() {
         super(RDFXMLExtractorFactory.NAME, RDFXMLExtractorFactory.PREFIXES,
-                Arrays.asList("application/rdf+xml", "text/rdf", "text/rdf+xml", "application/rdf"
-                // "application/xml;q=0.2",
-                // "text/xml;q=0.2"
-                ), "example-rdfxml.rdf");
+                Arrays.asList("application/rdf+xml", "text/rdf", "text/rdf+xml", "application/rdf"),
+                "example-rdfxml.rdf");
     }
 
     @Override

--- a/core/src/main/java/org/apache/any23/extractor/yaml/ElementsProcessor.java
+++ b/core/src/main/java/org/apache/any23/extractor/yaml/ElementsProcessor.java
@@ -33,6 +33,7 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModelFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.Literals;
+import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 
@@ -115,7 +116,7 @@ public class ElementsProcessor {
         } else if (t == null) {
             return asModelHolder(vocab.nullValue, modelFactory.createEmptyModel());
         } else {
-            return asModelHolder(Literals.createLiteral(vf, t), modelFactory.createEmptyModel());
+            return asModelHolder(Values.literal(t), modelFactory.createEmptyModel());
         }
     }
 

--- a/core/src/test/java/org/apache/any23/extractor/calendar/BaseCalendarExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/calendar/BaseCalendarExtractorTest.java
@@ -27,6 +27,7 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.junit.Assert;
 
 import java.io.File;
@@ -59,8 +60,9 @@ abstract class BaseCalendarExtractorTest extends AbstractExtractorTestCase {
         RDFParser nQuadsParser = Rio.createParser(RDFFormat.NQUADS);
         TestRDFHandler rdfHandler = new TestRDFHandler();
         nQuadsParser.setRDFHandler(rdfHandler);
+        nQuadsParser.setParseErrorListener(new ParseErrorCollector());
         File file = copyResourceToTempFile(resultFilePath);
-        nQuadsParser.parse(new FileReader(file, StandardCharsets.UTF_8), baseIRI.toString());
+        nQuadsParser.parse(new FileReader(file, StandardCharsets.UTF_8), baseIRI.stringValue());
         return rdfHandler.getStatements();
     }
 
@@ -87,7 +89,6 @@ abstract class BaseCalendarExtractorTest extends AbstractExtractorTestCase {
         }
 
         public void handleComment(String s) throws RDFHandlerException {
-            throw new UnsupportedOperationException();
         }
     }
 }

--- a/core/src/test/java/org/apache/any23/extractor/csv/CSVExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/csv/CSVExtractorTest.java
@@ -23,7 +23,7 @@ import org.apache.any23.vocab.CSV;
 import org.junit.Test;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,9 +50,8 @@ public class CSVExtractorTest extends AbstractExtractorTestCase {
         assertModelNotEmpty();
         assertStatementsSize(null, null, null, 28);
         assertStatementsSize(null, RDF.TYPE, csv.rowType, 3);
-        assertContains(null, csv.numberOfColumns,
-                SimpleValueFactory.getInstance().createLiteral("4", XMLSchema.INTEGER));
-        assertContains(null, csv.numberOfRows, SimpleValueFactory.getInstance().createLiteral("3", XMLSchema.INTEGER));
+        assertContains(null, csv.numberOfColumns, SimpleValueFactory.getInstance().createLiteral("4", XSD.INTEGER));
+        assertContains(null, csv.numberOfRows, SimpleValueFactory.getInstance().createLiteral("3", XSD.INTEGER));
     }
 
     @Test
@@ -64,9 +63,8 @@ public class CSVExtractorTest extends AbstractExtractorTestCase {
         assertModelNotEmpty();
         assertStatementsSize(null, null, null, 28);
         assertStatementsSize(null, RDF.TYPE, csv.rowType, 3);
-        assertContains(null, csv.numberOfColumns,
-                SimpleValueFactory.getInstance().createLiteral("4", XMLSchema.INTEGER));
-        assertContains(null, csv.numberOfRows, SimpleValueFactory.getInstance().createLiteral("3", XMLSchema.INTEGER));
+        assertContains(null, csv.numberOfColumns, SimpleValueFactory.getInstance().createLiteral("4", XSD.INTEGER));
+        assertContains(null, csv.numberOfRows, SimpleValueFactory.getInstance().createLiteral("3", XSD.INTEGER));
     }
 
     @Test
@@ -78,9 +76,8 @@ public class CSVExtractorTest extends AbstractExtractorTestCase {
         assertModelNotEmpty();
         assertStatementsSize(null, null, null, 28);
         assertStatementsSize(null, RDF.TYPE, csv.rowType, 3);
-        assertContains(null, csv.numberOfColumns,
-                SimpleValueFactory.getInstance().createLiteral("4", XMLSchema.INTEGER));
-        assertContains(null, csv.numberOfRows, SimpleValueFactory.getInstance().createLiteral("3", XMLSchema.INTEGER));
+        assertContains(null, csv.numberOfColumns, SimpleValueFactory.getInstance().createLiteral("4", XSD.INTEGER));
+        assertContains(null, csv.numberOfRows, SimpleValueFactory.getInstance().createLiteral("3", XSD.INTEGER));
     }
 
     @Test
@@ -92,12 +89,11 @@ public class CSVExtractorTest extends AbstractExtractorTestCase {
         assertModelNotEmpty();
         assertStatementsSize(null, null, null, 21);
         assertStatementsSize(null, RDF.TYPE, csv.rowType, 3);
-        assertContains(null, csv.numberOfColumns,
-                SimpleValueFactory.getInstance().createLiteral("2", XMLSchema.INTEGER));
-        assertContains(null, csv.numberOfRows, SimpleValueFactory.getInstance().createLiteral("3", XMLSchema.INTEGER));
-        assertContains(null, null, SimpleValueFactory.getInstance().createLiteral("5.2", XMLSchema.FLOAT));
-        assertContains(null, null, SimpleValueFactory.getInstance().createLiteral("7.9", XMLSchema.FLOAT));
-        assertContains(null, null, SimpleValueFactory.getInstance().createLiteral("10", XMLSchema.INTEGER));
+        assertContains(null, csv.numberOfColumns, SimpleValueFactory.getInstance().createLiteral("2", XSD.INTEGER));
+        assertContains(null, csv.numberOfRows, SimpleValueFactory.getInstance().createLiteral("3", XSD.INTEGER));
+        assertContains(null, null, SimpleValueFactory.getInstance().createLiteral("5.2", XSD.FLOAT));
+        assertContains(null, null, SimpleValueFactory.getInstance().createLiteral("7.9", XSD.FLOAT));
+        assertContains(null, null, SimpleValueFactory.getInstance().createLiteral("10", XSD.INTEGER));
     }
 
     @Test
@@ -109,11 +105,10 @@ public class CSVExtractorTest extends AbstractExtractorTestCase {
         assertModelNotEmpty();
         assertStatementsSize(null, null, null, 25);
         assertStatementsSize(null, RDF.TYPE, csv.rowType, 3);
-        assertContains(null, csv.numberOfColumns,
-                SimpleValueFactory.getInstance().createLiteral("4", XMLSchema.INTEGER));
-        assertContains(null, csv.numberOfRows, SimpleValueFactory.getInstance().createLiteral("3", XMLSchema.INTEGER));
-        assertContains(null, null, SimpleValueFactory.getInstance().createLiteral("Michele", XMLSchema.STRING));
-        assertContains(null, null, SimpleValueFactory.getInstance().createLiteral("Giovanni", XMLSchema.STRING));
+        assertContains(null, csv.numberOfColumns, SimpleValueFactory.getInstance().createLiteral("4", XSD.INTEGER));
+        assertContains(null, csv.numberOfRows, SimpleValueFactory.getInstance().createLiteral("3", XSD.INTEGER));
+        assertContains(null, null, SimpleValueFactory.getInstance().createLiteral("Michele", XSD.STRING));
+        assertContains(null, null, SimpleValueFactory.getInstance().createLiteral("Giovanni", XSD.STRING));
     }
 
 }

--- a/core/src/test/java/org/apache/any23/extractor/html/AbstractExtractorTestCase.java
+++ b/core/src/test/java/org/apache/any23/extractor/html/AbstractExtractorTestCase.java
@@ -74,7 +74,6 @@ public abstract class AbstractExtractorTestCase extends AbstractAny23TestBase {
     /**
      * Base test document.
      */
-    // TODO: change base IRI string.
     protected static IRI baseIRI = RDFUtils.iri("http://bob.example.com/");
 
     /**
@@ -194,8 +193,8 @@ public abstract class AbstractExtractorTestCase extends AbstractAny23TestBase {
     // tests should be based on mimetype detection.
     protected void extract(String resource) throws ExtractionException, IOException {
         SingleDocumentExtraction ex = new SingleDocumentExtraction(
-                new HTMLFixture(copyResourceToTempFile(resource)).getOpener(baseIRI.toString()), getExtractorFactory(),
-                new RepositoryWriter(conn));
+                new HTMLFixture(copyResourceToTempFile(resource)).getOpener(baseIRI.stringValue()),
+                getExtractorFactory(), new RepositoryWriter(conn));
         ex.setMIMETypeDetector(null);
         report = ex.run();
     }

--- a/core/src/test/java/org/apache/any23/extractor/microdata/MicrodataExtractorTest.java
+++ b/core/src/test/java/org/apache/any23/extractor/microdata/MicrodataExtractorTest.java
@@ -220,8 +220,6 @@ public class MicrodataExtractorTest extends AbstractExtractorTestCase {
                 if (result != null) {
                     createRunner(TurtleExtractorFactory.NAME).extract(result.stringValue(), new TripleWriterHandler() {
                         public void writeTriple(Resource s, IRI p, Value o, Resource g) {
-                            // TODO: remove this if-block after https://github.com/w3c/microdata-rdf/issues/30 has been
-                            // resolved
                             if (o instanceof IRI
                                     && o.stringValue().equals("http://w3c.github.io/author/jd_salinger.html")) {
                                 o = RDFUtils.iri("https://w3c.github.io/author/jd_salinger.html");
@@ -504,7 +502,7 @@ public class MicrodataExtractorTest extends AbstractExtractorTestCase {
         TestRDFHandler rdfHandler = new TestRDFHandler();
         nQuadsParser.setRDFHandler(rdfHandler);
         File file = copyResourceToTempFile(resultFilePath);
-        nQuadsParser.parse(new FileReader(file, StandardCharsets.UTF_8), baseIRI.toString());
+        nQuadsParser.parse(new FileReader(file, StandardCharsets.UTF_8), baseIRI.stringValue());
         return rdfHandler.getStatements();
     }
 
@@ -531,7 +529,6 @@ public class MicrodataExtractorTest extends AbstractExtractorTestCase {
         }
 
         public void handleComment(String s) throws RDFHandlerException {
-            throw new UnsupportedOperationException();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,8 @@
     <javac.target.version>11</javac.target.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ssZ</maven.build.timestamp.format>
+    <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
+    <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     <implementation.build>${scmBranch}@r${buildNumber}</implementation.build>
     <implementation.build.tstamp>${maven.build.timestamp}</implementation.build.tstamp>
     <project.build.outputTimestamp>1</project.build.outputTimestamp>
@@ -247,7 +249,7 @@
     <httpcore.version>4.4.14</httpcore.version>
     <owlapi.version>5.1.19</owlapi.version>
     <poi.version>5.0.0</poi.version>
-    <rdf4j.version>3.1.2</rdf4j.version>
+    <rdf4j.version>3.7.3</rdf4j.version>
     <semargl.version>0.7</semargl.version>
     <slf4j.logger.version>1.7.32</slf4j.logger.version>
     <tika.version>2.1.0</tika.version>


### PR DESCRIPTION
This PR addresses https://issues.apache.org/jira/browse/ANY23-523 and supersedes #203 

I encountered a classpath conflict between the older RDF4J dependencies and the newly proposed owl-api ones. This PR therefore upgrades both 