### PR TITLE
make build reproducible

### DIFF
--- a/api/src/main/resources/default-configuration.properties
+++ b/api/src/main/resources/default-configuration.properties
@@ -16,7 +16,7 @@
 #
 
 # Any23 Core Version
-any23.core.version=${project.version} (${implementation.build.tstamp})
+any23.core.version=${project.version}
 
 # HTTP Client Configuration.
 # ---- Default HTTP User Agent if not specified.

--- a/cli/src/main/assembly/README.txt
+++ b/cli/src/main/assembly/README.txt
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-Apache Any23 ${project.version} (${implementation.build.tstamp})
+Apache Any23 ${project.version}
 
   What is it?
   -----------

--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
     <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <appassembler-maven-plugin.version>2.1.0</appassembler-maven-plugin.version>
-    <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+    <maven-release-plugin.version>3.0.0-M5</maven-release-plugin.version>
     <buildnumber-maven-plugin.version>3.0.0</buildnumber-maven-plugin.version>
     <maven-compiler-plugin.version>3.10.0</maven-compiler-plugin.version>
     <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
@@ -933,7 +933,6 @@
             </manifest>
             <manifestEntries>
               <Implementation-Build>${implementation.build}</Implementation-Build>
-              <Implementation-Build-Date>${maven.build.timestamp}</Implementation-Build-Date>
               <X-Compile-Source-JDK>${javac.src.version}</X-Compile-Source-JDK>
               <X-Compile-Target-JDK>${javac.target.version}</X-Compile-Target-JDK>
             </manifestEntries>
@@ -1150,7 +1149,6 @@
                     </manifest>
                     <manifestEntries>
                       <Implementation-Build>${implementation.build}</Implementation-Build>
-                      <Implementation-Build-Date>${maven.build.timestamp}</Implementation-Build-Date>
                       <X-Compile-Source-JDK>${javac.src.version}</X-Compile-Source-JDK>
                       <X-Compile-Target-JDK>${javac.target.version}</X-Compile-Target-JDK>
                     </manifestEntries>
@@ -1179,7 +1177,6 @@
                     </manifest>
                     <manifestEntries>
                       <Implementation-Build>${implementation.build}</Implementation-Build>
-                      <Implementation-Build-Date>${maven.build.timestamp}</Implementation-Build-Date>
                       <X-Compile-Source-JDK>${javac.src.version}</X-Compile-Source-JDK>
                       <X-Compile-Target-JDK>${javac.target.version}</X-Compile-Target-JDK>
                     </manifestEntries>


### PR DESCRIPTION
release 2.7 is not fully reproducible: https://github.com/jvm-repo-rebuild/reproducible-central#org.apache.any23:apache-any23

there are a few issues https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/any23/apache-any23-2.7.diffoscope
some are because of old plugins versions, some because of build timestamp put in generated content

this PR fixes issues, you can test by running:
```
mvn clean install -Papache-release -DskipTests -Dgpg.skip && mvn clean package -Papache-release -DskipTests -Dgpg.skip artifact:compare
```